### PR TITLE
Fixes hiding of disclaimer view

### DIFF
--- a/DP3TApp/Screens/Onboarding/NSOnboardingDisclaimerViewController.swift
+++ b/DP3TApp/Screens/Onboarding/NSOnboardingDisclaimerViewController.swift
@@ -86,8 +86,13 @@ class NSOnboardingDisclaimerViewController: NSOnboardingContentViewController {
         warningContainer.addSubview(warningStack)
         addArrangedView(warningContainer, spacing: NSPadding.large, insets: sidePadding)
 
-        stackScrollView.addSpacerView(NSPadding.large)
+        let spacerView = UIView()
+        addArrangedView(spacerView)
 
+        spacerView.snp.makeConstraints { make in
+            make.height.equalTo(NSPadding.large)
+        }
+        
         warningStack.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }


### PR DESCRIPTION
Since we added a spacer via the stackview.addSpacer extension helper method instead of the NSOnboardingContentViewController (which wraps any view in a WrapperView before adding it to the stackView), when performing an onboarding step the NSOnboardingContentViewController.fadeAnimation would not call the completion handler since the last stackview element (= the spacer view) does not have any subviews.

As a consequence, the DisclaimerViewController View is not set to hidden after an onboarding step is taken. This behavior is only visible either in the view hierarchy inspector (see attached screenshot), or when running voiceover (since this would read out some of the hidden elements, one of them being the privacy info button for example) .

As a solution, we need to add a spacer view via the addArrangedView of the NSOnboardingContentViewController.

<img width="1306" alt="Screenshot 2020-07-08 at 19 31 15" src="https://user-images.githubusercontent.com/5672716/86965585-161d4d00-c168-11ea-8340-7515db7a212e.png">
