### PR TITLE
Add background refresh task to improve background scheduling

### DIFF
--- a/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/DP-3T/dp3t-sdk-ios.git",
         "state": {
           "branch": "develop",
-          "revision": "45a8d0abe378e7f51ba924ad52277d5d5de7445f",
+          "revision": "c2a807fd368fb945c43c602d9d3797693f679932",
           "version": null
         }
       },

--- a/DP3TApp/Logic/AppDelegate.swift
+++ b/DP3TApp/Logic/AppDelegate.swift
@@ -156,11 +156,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             TracingLocalPush.shared.clearNotifications()
         }
     }
-
-    func application(_: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        DatabaseSyncer.shared.performFetch(completionHandler: completionHandler)
-    }
-
     // MARK: - Force update
 
     private func startForceUpdateCheck() {

--- a/DP3TApp/Logic/Tracing/DatabaseSyncer.swift
+++ b/DP3TApp/Logic/Tracing/DatabaseSyncer.swift
@@ -23,10 +23,6 @@ class DatabaseSyncer {
 
     private var databaseSyncInterval: TimeInterval = 10
 
-    func performFetch(completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        syncDatabaseIfNeeded(completionHandler: completionHandler)
-    }
-
     func syncDatabaseIfNeeded(completionHandler: ((UIBackgroundFetchResult) -> Void)? = nil) {
         guard !databaseIsSyncing,
             UserStorage.shared.hasCompletedOnboarding else {

--- a/DP3TApp/Supporting Files/Info.plist
+++ b/DP3TApp/Supporting Files/Info.plist
@@ -5,6 +5,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.dpppt.exposure-notification</string>
+		<string>org.dpppt.refresh</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>


### PR DESCRIPTION
This pull-request depends on https://github.com/DP-3T/dp3t-sdk-ios/pull/183, which adds a background refresh task to improve background scheduling in certain cases.