### PR TITLE
test explanation box

### DIFF
--- a/DP3TApp/Screens/Homescreen/BegegnungenDetail/NSBluetoothSettingsControl.swift
+++ b/DP3TApp/Screens/Homescreen/BegegnungenDetail/NSBluetoothSettingsControl.swift
@@ -23,7 +23,16 @@ class NSBluetoothSettingsControl: UIView {
 
     private let switchControl = UISwitch()
 
-    private let tracingActiveView = NSInfoBoxView(title: "tracing_active_title".ub_localized, subText: "tracing_active_text".ub_localized, image: UIImage(named: "ic-check"), titleColor: .ns_blue, subtextColor: UIColor.ns_text, backgroundColor: .ns_blueBackground, dynamicIconTintColor: .ns_blue)
+    let tracingActiveView: NSInfoBoxView = {
+        var viewModel = NSInfoBoxView.ViewModel(title: "tracing_active_title".ub_localized,
+                                                subText: "tracing_active_text".ub_localized,
+                                                image: UIImage(named: "ic-check"),
+                                                titleColor: .ns_blue,
+                                                subtextColor: .ns_text)
+        viewModel.backgroundColor = .ns_blueBackground
+        viewModel.dynamicIconTintColor = .ns_blue
+        return .init(viewModel: viewModel)
+    }()
 
     private let tracingInfoView: UIView = {
         let view = UIView()

--- a/DP3TApp/Screens/Homescreen/Homescreen/Begegnungen/NSBegegnungenModuleView.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/Begegnungen/NSBegegnungenModuleView.swift
@@ -16,9 +16,29 @@ class NSBegegnungenModuleView: NSModuleBaseView {
         didSet { updateUI() }
     }
 
-    private let tracingActiveView = NSInfoBoxView(title: "tracing_active_title".ub_localized, subText: "tracing_active_text".ub_localized, image: UIImage(named: "ic-check")!, illustration: UIImage(named: "illu-tracking-active")!, titleColor: .ns_blue, subtextColor: .ns_text, backgroundColor: .ns_blueBackground, dynamicIconTintColor: .ns_blue)
+    let tracingActiveView: NSInfoBoxView = {
+        var viewModel = NSInfoBoxView.ViewModel(title: "tracing_active_title".ub_localized,
+                                                subText: "tracing_active_text".ub_localized,
+                                                image: UIImage(named: "ic-check"),
+                                                titleColor: .ns_blue,
+                                                subtextColor: .ns_text)
+        viewModel.illustration = UIImage(named: "illu-tracking-active")!
+        viewModel.backgroundColor = .ns_blueBackground
+        viewModel.dynamicIconTintColor = .ns_blue
+        return .init(viewModel: viewModel)
+    }()
 
-    private let tracingEndedView = NSInfoBoxView(title: "tracing_ended_title".ub_localized, subText: "tracing_ended_text".ub_localized, image: UIImage(named: "ic-stopp")!, illustration: UIImage(named: "illu-tracing-ended")!, titleColor: .ns_purple, subtextColor: .ns_text, backgroundColor: .ns_purpleBackground, dynamicIconTintColor: .ns_purple)
+    let tracingEndedView: NSInfoBoxView = {
+        var viewModel = NSInfoBoxView.ViewModel(title: "tracing_ended_title".ub_localized,
+                                                subText: "tracing_ended_text".ub_localized,
+                                                image: UIImage(named: "ic-stopp"),
+                                                titleColor: .ns_purple,
+                                                subtextColor: .ns_text)
+        viewModel.illustration = UIImage(named: "illu-tracing-ended")!
+        viewModel.backgroundColor = .ns_purpleBackground
+        viewModel.dynamicIconTintColor = .ns_purple
+        return .init(viewModel: viewModel)
+    }()
 
     private let tracingInfoBox: UIView = {
         let view = UIView()

--- a/DP3TApp/Screens/Homescreen/Homescreen/Meldung/NSMeldungModuleView.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/Meldung/NSMeldungModuleView.swift
@@ -17,11 +17,42 @@ class NSMeldungView: NSModuleBaseView {
     }
 
     // section views
-    private let noMeldungenView = NSInfoBoxView(title: "meldungen_no_meldungen_title".ub_localized, subText: "meldungen_no_meldungen_subtitle".ub_localized, image: UIImage(named: "ic-check")!, illustration: UIImage(named: "illu-no-message")!, titleColor: .ns_green, subtextColor: .ns_text, backgroundColor: .ns_greenBackground, dynamicIconTintColor: .ns_green)
 
-    private let exposedView = NSInfoBoxView(title: "meldungen_meldung_title".ub_localized, subText: "meldungen_meldung_text".ub_localized, image: UIImage(named: "ic-info")!, titleColor: .white, subtextColor: .white, backgroundColor: .ns_blue, hasBubble: true, dynamicIconTintColor: .white)
+    let noMeldungenView: NSInfoBoxView = {
+        var viewModel = NSInfoBoxView.ViewModel(title: "meldungen_no_meldungen_title".ub_localized,
+                                                subText: "meldungen_no_meldungen_subtitle".ub_localized,
+                                                image: UIImage(named: "ic-check"),
+                                                titleColor: .ns_green,
+                                                subtextColor: .ns_text)
+        viewModel.illustration = UIImage(named: "illu-no-message")!
+        viewModel.backgroundColor = .ns_greenBackground
+        viewModel.dynamicIconTintColor = .ns_green
+        return .init(viewModel: viewModel)
+    }()
 
-    private let infectedView = NSInfoBoxView(title: "meldung_homescreen_positiv_title".ub_localized, subText: "meldung_homescreen_positiv_text".ub_localized, image: UIImage(named: "ic-info")!, titleColor: .white, subtextColor: .white, backgroundColor: .ns_purple, hasBubble: true, dynamicIconTintColor: .white)
+    let exposedView: NSInfoBoxView = {
+        var viewModel = NSInfoBoxView.ViewModel(title: "meldungen_meldung_title".ub_localized,
+                                                subText: "meldungen_meldung_text".ub_localized,
+                                                image: UIImage(named: "ic-info"),
+                                                titleColor: .white,
+                                                subtextColor: .white)
+        viewModel.hasBubble = true
+        viewModel.backgroundColor = .ns_blue
+        viewModel.dynamicIconTintColor = .white
+        return .init(viewModel: viewModel)
+    }()
+
+    let infectedView: NSInfoBoxView = {
+        var viewModel = NSInfoBoxView.ViewModel(title: "meldung_homescreen_positiv_title".ub_localized,
+                                                subText: "meldung_homescreen_positiv_text".ub_localized,
+                                                image: UIImage(named: "ic-info"),
+                                                titleColor: .white,
+                                                subtextColor: .white)
+        viewModel.hasBubble = true
+        viewModel.backgroundColor = .ns_purple
+        viewModel.dynamicIconTintColor = .white
+        return .init(viewModel: viewModel)
+    }()
 
     private let noPushView = NSTracingErrorView(model: NSTracingErrorView.NSTracingErrorViewModel(icon: UIImage(named: "ic-push-disabled")!, title: "push_deactivated_title".ub_localized, text: "push_deactivated_text".ub_localized, buttonTitle: "push_open_settings_button".ub_localized, action: { _ in
         guard let settingsUrl = URL(string: UIApplication.openSettingsURLString),

--- a/DP3TApp/Screens/Homescreen/Homescreen/NSHomescreenViewController.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/NSHomescreenViewController.swift
@@ -141,7 +141,12 @@ class NSHomescreenViewController: NSTitleViewScrollViewController {
         #if ENABLE_TESTING
             #if ENABLE_STATUS_OVERRIDE
                 // DEBUG version for testing
-                let previewWarning = NSInfoBoxView(title: "preview_warning_title".ub_localized, subText: "preview_warning_text".ub_localized, image: UIImage(named: "ic-error")!, titleColor: .gray, subtextColor: .gray)
+                var previewWarningViewModel = NSInfoBoxView.ViewModel(title: "preview_warning_title".ub_localized,
+                                                                      subText: "preview_warning_text".ub_localized,
+                                                                      titleColor: .gray,
+                                                                      subtextColor: .gray)
+                previewWarningViewModel.image = UIImage(named: "ic-error")!
+                let previewWarning = NSInfoBoxView(viewModel: previewWarningViewModel)
                 stackScrollView.addArrangedView(previewWarning)
 
                 stackScrollView.addSpacerView(NSPadding.large)

--- a/DP3TApp/Screens/Homescreen/ProblemView/HomescreenInfoBoxView.swift
+++ b/DP3TApp/Screens/Homescreen/ProblemView/HomescreenInfoBoxView.swift
@@ -27,6 +27,8 @@ class HomescreenInfoBoxView: UIView {
         var viewModel = NSInfoBoxView.ViewModel(title: "", subText: "", image: UIImage(named: "ic-info"), titleColor: .white, subtextColor: .white)
         viewModel.backgroundColor = .ns_darkBlueBackground
         viewModel.dynamicIconTintColor = .white
+        viewModel.additionalURL = ""
+        viewModel.additionalText = ""
         return .init(viewModel: viewModel)
     }()
 

--- a/DP3TApp/Screens/Homescreen/ProblemView/HomescreenInfoBoxView.swift
+++ b/DP3TApp/Screens/Homescreen/ProblemView/HomescreenInfoBoxView.swift
@@ -23,7 +23,12 @@ class HomescreenInfoBoxView: UIView {
 
     // MARK: - Views
 
-    let infoBoxView = NSInfoBoxView(title: "", subText: "", image: UIImage(named: "ic-info"), illustration: nil, titleColor: UIColor.white, subtextColor: UIColor.white, backgroundColor: .ns_darkBlueBackground, additionalText: "", additionalURL: "", dynamicIconTintColor: UIColor.white)
+    let infoBoxView: NSInfoBoxView = {
+        var viewModel = NSInfoBoxView.ViewModel(title: "", subText: "", image: UIImage(named: "ic-info"), titleColor: .white, subtextColor: .white)
+        viewModel.backgroundColor = .ns_darkBlueBackground
+        viewModel.dynamicIconTintColor = .white
+        return .init(viewModel: viewModel)
+    }()
 
     // MARK: - Init
 

--- a/DP3TApp/Screens/Meldungen/NSMeldungDetailMeldungenViewController.swift
+++ b/DP3TApp/Screens/Meldungen/NSMeldungDetailMeldungenViewController.swift
@@ -233,7 +233,7 @@ class NSMeldungDetailMeldungenViewController: NSTitleViewScrollViewController {
     }
 
     private func createExplanationView() -> UIView {
-        let ev = NSExplanationView(title: "meldungen_detail_explanation_title".ub_localized, texts: ["meldungen_detail_explanation_text1".ub_localized, "meldungen_detail_explanation_text2".ub_localized, "meldungen_detail_explanation_text3".ub_localized, "meldungen_detail_explanation_text4".ub_localized], edgeInsets: .zero)
+        let ev = NSExplanationView(title: "meldungen_detail_explanation_title".ub_localized, texts: ["meldungen_detail_explanation_text1".ub_localized, "meldungen_detail_explanation_text2".ub_localized, "meldungen_detail_explanation_text3".ub_localized], edgeInsets: .zero)
 
         let wrapper = UIView()
         let daysLeftLabel = NSLabel(.textBold)
@@ -246,6 +246,16 @@ class NSMeldungDetailMeldungenViewController: NSTitleViewScrollViewController {
 
         ev.stackView.insertArrangedSubview(wrapper, at: 3)
         ev.stackView.setCustomSpacing(NSPadding.small, after: ev.stackView.arrangedSubviews[2])
+
+        let infoxBoxView = NSInfoBoxView(title: "meldungen_detail_free_tests_title".ub_localized,
+                                         subText: "meldungen_detail_free_tests_text".ub_localized,
+                                         image: UIImage(named: "ic-info-on"),
+                                         titleColor: .ns_text,
+                                         subtextColor: .ns_text,
+                                         backgroundColor: .ns_blueBackground,
+                                         titleLabelType: .textBold)
+
+        ev.stackView.addArrangedSubview(infoxBoxView)
 
         return ev
     }

--- a/DP3TApp/Screens/Meldungen/NSMeldungDetailMeldungenViewController.swift
+++ b/DP3TApp/Screens/Meldungen/NSMeldungDetailMeldungenViewController.swift
@@ -247,15 +247,17 @@ class NSMeldungDetailMeldungenViewController: NSTitleViewScrollViewController {
         ev.stackView.insertArrangedSubview(wrapper, at: 3)
         ev.stackView.setCustomSpacing(NSPadding.small, after: ev.stackView.arrangedSubviews[2])
 
-        let infoxBoxView = NSInfoBoxView(title: "meldungen_detail_free_tests_title".ub_localized,
-                                         subText: "meldungen_detail_free_tests_text".ub_localized,
-                                         image: UIImage(named: "ic-info-on"),
-                                         titleColor: .ns_text,
-                                         subtextColor: .ns_text,
-                                         backgroundColor: .ns_blueBackground,
-                                         titleLabelType: .textBold)
+        var infoBoxViewModel = NSInfoBoxView.ViewModel(title: "meldungen_detail_free_tests_title".ub_localized,
+                                                       subText: "meldungen_detail_free_tests_text".ub_localized,
+                                                       titleColor: .ns_text,
+                                                       subtextColor: .ns_text)
+        infoBoxViewModel.image = UIImage(named: "ic-info-on")
+        infoBoxViewModel.backgroundColor = .ns_blueBackground
+        infoBoxViewModel.titleLabelType = .textBold
 
-        ev.stackView.addArrangedSubview(infoxBoxView)
+        let infoBoxView = NSInfoBoxView(viewModel: infoBoxViewModel)
+
+        ev.stackView.addArrangedSubview(infoBoxView)
 
         return ev
     }

--- a/DP3TApp/SharedUI/Views/NSInfoBoxView.swift
+++ b/DP3TApp/SharedUI/Views/NSInfoBoxView.swift
@@ -45,21 +45,36 @@ class NSInfoBoxView: UIView {
 
     // MARK: - Init
 
-    init(title: String, subText: String, image: UIImage?, illustration: UIImage? = nil, titleColor: UIColor, subtextColor: UIColor, backgroundColor: UIColor? = nil, hasBubble: Bool = false, additionalText: String? = nil, additionalURL: String? = nil, dynamicIconTintColor: UIColor? = nil, titleLabelType: NSLabelType = .uppercaseBold) {
-        leadingIconImageView = NSImageView(image: image, dynamicColor: dynamicIconTintColor)
-        titleLabel = NSLabel(titleLabelType)
+    struct ViewModel {
+        var title: String
+        var subText: String
+        var image: UIImage?
+        var illustration: UIImage? = nil
+        var titleColor: UIColor
+        var subtextColor: UIColor
+        var backgroundColor: UIColor? = nil
+        var hasBubble: Bool = false
+        var additionalText: String? = nil
+        var additionalURL: String? = nil
+        var dynamicIconTintColor: UIColor? = nil
+        var titleLabelType: NSLabelType = .uppercaseBold
+    }
+
+    init(viewModel: ViewModel) {
+        leadingIconImageView = NSImageView(image: viewModel.image, dynamicColor: viewModel.dynamicIconTintColor)
+        titleLabel = NSLabel(viewModel.titleLabelType)
 
         super.init(frame: .zero)
 
-        titleLabel.text = title
-        subtextLabel.text = subText
-        titleLabel.textColor = titleColor
-        subtextLabel.textColor = subtextColor
-        additionalLabel.textColor = subtextColor
-        illustrationImageView.image = illustration
+        titleLabel.text = viewModel.title
+        subtextLabel.text = viewModel.subText
+        titleLabel.textColor = viewModel.titleColor
+        subtextLabel.textColor = viewModel.subtextColor
+        additionalLabel.textColor = viewModel.subtextColor
+        illustrationImageView.image = viewModel.illustration
 
-        setup(backgroundColor: backgroundColor, hasBubble: hasBubble, additionalText: additionalText, additionalURL: additionalURL)
-        setupAccessibility(title: title, subText: subText)
+        setup(viewModel: viewModel)
+        setupAccessibility(viewModel: viewModel)
     }
 
     required init?(coder _: NSCoder) {
@@ -68,12 +83,12 @@ class NSInfoBoxView: UIView {
 
     // MARK: - Setup
 
-    private func setup(backgroundColor: UIColor?, hasBubble: Bool, additionalText: String? = nil, additionalURL: String? = nil) {
+    private func setup(viewModel: ViewModel) {
         clipsToBounds = false
 
         var topBottomPadding: CGFloat = 0
 
-        if let bgc = backgroundColor {
+        if let bgc = viewModel.backgroundColor {
             let v = UIView()
             v.layer.cornerRadius = 3.0
             addSubview(v)
@@ -84,7 +99,7 @@ class NSInfoBoxView: UIView {
 
             v.backgroundColor = bgc
 
-            if hasBubble {
+            if viewModel.hasBubble {
                 let imageView = NSImageView(image: UIImage(named: "bubble"), dynamicColor: bgc)
                 addSubview(imageView)
 
@@ -97,7 +112,7 @@ class NSInfoBoxView: UIView {
             topBottomPadding = 14
         }
 
-        let hasAdditionalStuff = additionalText != nil
+        let hasAdditionalStuff = viewModel.additionalText != nil
 
         addSubview(titleLabel)
         addSubview(subtextLabel)
@@ -134,8 +149,8 @@ class NSInfoBoxView: UIView {
             }
         }
 
-        if let adt = additionalText {
-            if let url = additionalURL {
+        if let adt = viewModel.additionalText {
+            if let url = viewModel.additionalURL {
                 addSubview(externalLinkButton)
                 externalLinkButton.title = adt
 
@@ -179,8 +194,8 @@ class NSInfoBoxView: UIView {
 // MARK: - Accessibility
 
 extension NSInfoBoxView {
-    private func setupAccessibility(title: String, subText: String) {
+    private func setupAccessibility(viewModel: ViewModel) {
         isAccessibilityElement = true
-        accessibilityLabel = "\(title), \(subText)"
+        accessibilityLabel = "\(viewModel.title), \(viewModel.subText)"
     }
 }

--- a/DP3TApp/SharedUI/Views/NSInfoBoxView.swift
+++ b/DP3TApp/SharedUI/Views/NSInfoBoxView.swift
@@ -31,8 +31,7 @@ class NSInfoBoxView: UIView {
             externalLinkButton.title = additionalText
 
             externalLinkButton.touchUpCallback = { [weak self] in
-                guard let strongSelf = self else { return }
-                strongSelf.openLink(url)
+                self?.openLink(url)
             }
 
             illustrationImageView.isHidden = false
@@ -155,8 +154,7 @@ class NSInfoBoxView: UIView {
                 externalLinkButton.title = adt
 
                 externalLinkButton.touchUpCallback = { [weak self] in
-                    guard let strongSelf = self else { return }
-                    strongSelf.openLink(url)
+                    self?.openLink(url)
                 }
 
                 externalLinkButton.snp.makeConstraints { make in

--- a/DP3TApp/SharedUI/Views/NSInfoBoxView.swift
+++ b/DP3TApp/SharedUI/Views/NSInfoBoxView.swift
@@ -13,7 +13,7 @@ import UIKit
 class NSInfoBoxView: UIView {
     // MARK: - Views
 
-    private let titleLabel = NSLabel(.uppercaseBold)
+    private let titleLabel: NSLabel
     private let subtextLabel = NSLabel(.textLight)
     private let leadingIconImageView: NSImageView
     private let illustrationImageView = UIImageView()
@@ -45,8 +45,9 @@ class NSInfoBoxView: UIView {
 
     // MARK: - Init
 
-    init(title: String, subText: String, image: UIImage?, illustration: UIImage? = nil, titleColor: UIColor, subtextColor: UIColor, backgroundColor: UIColor? = nil, hasBubble: Bool = false, additionalText: String? = nil, additionalURL: String? = nil, dynamicIconTintColor: UIColor? = nil) {
+    init(title: String, subText: String, image: UIImage?, illustration: UIImage? = nil, titleColor: UIColor, subtextColor: UIColor, backgroundColor: UIColor? = nil, hasBubble: Bool = false, additionalText: String? = nil, additionalURL: String? = nil, dynamicIconTintColor: UIColor? = nil, titleLabelType: NSLabelType = .uppercaseBold) {
         leadingIconImageView = NSImageView(image: image, dynamicColor: dynamicIconTintColor)
+        titleLabel = NSLabel(titleLabelType)
 
         super.init(frame: .zero)
 

--- a/Translations/bs.lproj/Localizable.strings
+++ b/Translations/bs.lproj/Localizable.strings
@@ -905,3 +905,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Praćenje je deaktivirano";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -912,3 +912,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Tracing wurde deaktiviert";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "Kostenloser Test möglich";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "Die Infoline SwissCovid berät Sie über die Möglichkeit eines kostenlosen Corona Tests.";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -895,3 +895,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Tracing has been deactivated";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/es.lproj/Localizable.strings
+++ b/Translations/es.lproj/Localizable.strings
@@ -888,3 +888,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Se ha desactivado el rastreo";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/fr.lproj/Localizable.strings
+++ b/Translations/fr.lproj/Localizable.strings
@@ -903,3 +903,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Traçage désactivé";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/hr.lproj/Localizable.strings
+++ b/Translations/hr.lproj/Localizable.strings
@@ -888,3 +888,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Praćenje je deaktivirano";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/it.lproj/Localizable.strings
+++ b/Translations/it.lproj/Localizable.strings
@@ -897,3 +897,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Tracciamento disattivato";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/pt.lproj/Localizable.strings
+++ b/Translations/pt.lproj/Localizable.strings
@@ -888,3 +888,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Foi desativado o rastreamento";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/rm.lproj/Localizable.strings
+++ b/Translations/rm.lproj/Localizable.strings
@@ -890,3 +890,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Tracing è vegnì deactivà";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/sq.lproj/Localizable.strings
+++ b/Translations/sq.lproj/Localizable.strings
@@ -888,3 +888,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Gjurmimi u çaktivizua";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/sr-Latn-RS.lproj/Localizable.strings
+++ b/Translations/sr-Latn-RS.lproj/Localizable.strings
@@ -888,3 +888,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Praćenje je deaktivirano";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/ti.lproj/Localizable.strings
+++ b/Translations/ti.lproj/Localizable.strings
@@ -856,7 +856,7 @@
 "onboarding_disclaimer_app_version" = "ዓይነት ስዊስኮቪድ ኣፕ";
 
 /*Onboarding Disclaimer Screen: Release version title*/
-"onboarding_disclaimer_release_version" = "ዝወጻሉ መዓልቲ፦ Release Date:  ";
+"onboarding_disclaimer_release_version" = "Release Date:";
 
 /*onboarding privacy and conditions of use button*/
 "onboarding_disclaimer_legal_button" = "መግለጺ ናይ ምክልኻል ውልቃዊ ሰነድን ንምጥቃም ክማልኡ ዘለዎም ነገራትን";
@@ -884,3 +884,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "ምክትታል ተቛሪጹ (ከም ዘይሰርሕ ተጌሩ)";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";

--- a/Translations/tr.lproj/Localizable.strings
+++ b/Translations/tr.lproj/Localizable.strings
@@ -309,7 +309,7 @@
 "meldungen_detail_call_again_button" = "Yeniden ara";
 
 /*Meldungen Detail: Weisse Box Anruf Zeitpunkt*/
-"meldungen_detail_call_last_call" = "Son arama: {TARİH}";
+"meldungen_detail_call_last_call" = "Son arama: {DATE}";
 
 /*Subtitel im Onboarding erste Seite*/
 "app_subtitle" = "Alt Başlık";
@@ -884,3 +884,9 @@
 
 /*Info to the user that tracing has been switched off*/
 "accessibility_tracing_has_been_deactivated" = "Takip devre dışı bırakılmıştır";
+
+/*Meldungen Detail Kostenloser Test Box Title*/
+"meldungen_detail_free_test_title" = "";
+
+/*Meldungen Detail Kostenloser Test Box Text*/
+"meldungen_detail_free_test_text" = "";


### PR DESCRIPTION
- a info box was added to the NSMeldungDetailMeldungenViewController to highlight the possibility to get tested without charge.
- NSInfoBoxView was refactored to use a view model in order to reduce code smell.