### PR TITLE
Info box fixes

### DIFF
--- a/DP3TApp.xcodeproj/project.pbxproj
+++ b/DP3TApp.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 		F88585EE249272EE00018AEA /* TracingLocalPushTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88585ED249272EE00018AEA /* TracingLocalPushTests.swift */; };
 		F88D99DB2497938E0081790E /* UIImage+localizedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88D99DA2497938E0081790E /* UIImage+localizedImage.swift */; };
 		F88D99DC2497957C0081790E /* UIImage+localizedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88D99DA2497938E0081790E /* UIImage+localizedImage.swift */; };
+		F891129C24C96C4300DCB111 /* ConfigResponseBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F891129B24C96C4300DCB111 /* ConfigResponseBodyTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -545,6 +546,7 @@
 		F865C8A224990A6800B730BD /* NSOnboardingDisclaimerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSOnboardingDisclaimerViewController.swift; sourceTree = "<group>"; };
 		F88585ED249272EE00018AEA /* TracingLocalPushTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TracingLocalPushTests.swift; sourceTree = "<group>"; };
 		F88D99DA2497938E0081790E /* UIImage+localizedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+localizedImage.swift"; sourceTree = "<group>"; };
+		F891129B24C96C4300DCB111 /* ConfigResponseBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigResponseBodyTests.swift; sourceTree = "<group>"; };
 		F8ABFC712474337000D621FF /* Entitlements_Calibration.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Entitlements_Calibration.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1045,6 +1047,7 @@
 				F85E4C0B24AC84BF00056864 /* MockNotificationCenter.swift */,
 				8E81CCAF241FCC7F006F2437 /* FakePublishManagerTests.swift */,
 				F88585ED249272EE00018AEA /* TracingLocalPushTests.swift */,
+				F891129B24C96C4300DCB111 /* ConfigResponseBodyTests.swift */,
 				8E81CCB1241FCC7F006F2437 /* Info.plist */,
 				F84089EF24936D8700A66CD1 /* MockKeychain.swift */,
 			);
@@ -1792,6 +1795,7 @@
 			files = (
 				F85E4C0C24AC84BF00056864 /* MockNotificationCenter.swift in Sources */,
 				F88585EE249272EE00018AEA /* TracingLocalPushTests.swift in Sources */,
+				F891129C24C96C4300DCB111 /* ConfigResponseBodyTests.swift in Sources */,
 				F84089F024936D8700A66CD1 /* MockKeychain.swift in Sources */,
 				8E81CCB0241FCC7F006F2437 /* FakePublishManagerTests.swift in Sources */,
 			);

--- a/DP3TApp/Logic/Config/ConfigResponseBody.swift
+++ b/DP3TApp/Logic/Config/ConfigResponseBody.swift
@@ -15,8 +15,9 @@ struct LocalizedValue<T: UBCodable>: UBCodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        dic = (try container.decode([String: T].self)).reduce(into: [String: T]()) { result, new in
-            result[String(new.key.prefix(2))] = new.value
+        dic = (try container.decode([String: T?].self)).reduce(into: [String: T]()) { result, new in
+            guard let value = new.value else { return }
+            result[String(new.key.prefix(2))] = value
         }
     }
 

--- a/DP3TApp/Logic/Config/ConfigResponseBody.swift
+++ b/DP3TApp/Logic/Config/ConfigResponseBody.swift
@@ -27,7 +27,11 @@ struct LocalizedValue<T: UBCodable>: UBCodable {
     }
 
     var value: T? {
-        return dic["language_key".ub_localized]
+        return value(for: "language_key".ub_localized)
+    }
+
+    func value(for languageKey: String) -> T? {
+        return dic[languageKey]
     }
 }
 

--- a/DP3TApp/Logic/Config/ConfigResponseBody.swift
+++ b/DP3TApp/Logic/Config/ConfigResponseBody.swift
@@ -35,7 +35,7 @@ struct LocalizedValue<T: UBCodable>: UBCodable {
             }
         }
 
-        return dic["en"] ?? nil
+        return nil
     }
 }
 

--- a/DP3TApp/Logic/Config/ConfigResponseBody.swift
+++ b/DP3TApp/Logic/Config/ConfigResponseBody.swift
@@ -26,16 +26,7 @@ struct LocalizedValue<T: UBCodable>: UBCodable {
     }
 
     var value: T? {
-        let preferredLanguages = Locale.preferredLanguages
-
-        for preferredLanguage in preferredLanguages {
-            if let code = preferredLanguage.components(separatedBy: "-").first,
-                let val = dic[code] {
-                return val
-            }
-        }
-
-        return nil
+        return dic["language_key".ub_localized]
     }
 }
 

--- a/DP3TApp/SharedUI/Controls/NSExternalLinkButton.swift
+++ b/DP3TApp/SharedUI/Controls/NSExternalLinkButton.swift
@@ -96,6 +96,7 @@ class NSExternalLinkButton: UBButton {
     // MARK: - Fix content size
 
     override public var intrinsicContentSize: CGSize {
+        guard !(self.title?.isEmpty ?? true) else { return .zero }
         var size = titleLabel?.intrinsicContentSize ?? super.intrinsicContentSize
         size.width = size.width + titleEdgeInsets.left + titleEdgeInsets.right + 30
         size.height = size.height + titleEdgeInsets.top + titleEdgeInsets.bottom + 10

--- a/DP3TApp/SharedUI/Views/NSInfoBoxView.swift
+++ b/DP3TApp/SharedUI/Views/NSInfoBoxView.swift
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import SnapKit
 import UIKit
 
 class NSInfoBoxView: UIView {
@@ -20,6 +21,9 @@ class NSInfoBoxView: UIView {
 
     private let additionalLabel = NSLabel(.textBold)
     private let externalLinkButton = NSExternalLinkButton()
+
+    private var externalLinkBottomConstraint: Constraint?
+    private var additionalLabelBottomConstraint: Constraint?
 
     // MARK: - Update
 
@@ -36,8 +40,14 @@ class NSInfoBoxView: UIView {
             }
 
             illustrationImageView.isHidden = false
+
+            externalLinkBottomConstraint?.update(inset: NSPadding.large)
         } else {
+            externalLinkButton.title = nil
+
             additionalLabel.text = additionalText
+
+            externalLinkBottomConstraint?.update(inset: 0)
 
             illustrationImageView.isHidden = true
         }
@@ -147,7 +157,7 @@ class NSInfoBoxView: UIView {
                     make.top.equalTo(self.subtextLabel.snp.bottom).offset(NSPadding.medium + NSPadding.small)
                     make.leading.equalTo(self.titleLabel)
                     make.trailing.lessThanOrEqualTo(self.titleLabel)
-                    make.bottom.equalToSuperview().inset(NSPadding.large)
+                    self.externalLinkBottomConstraint = make.bottom.equalToSuperview().inset(NSPadding.large).constraint
                 }
             } else {
                 addSubview(additionalLabel)

--- a/DP3TAppTests/ConfigResponseBodyTests.swift
+++ b/DP3TAppTests/ConfigResponseBodyTests.swift
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+@testable import DP3TApp
+import XCTest
+
+class ConfigResponseBodyTests: XCTestCase {
+    func testParsing() {
+        let json = """
+            {"forceUpdate": false,"forceTraceShutdown": false,"infoBox": {"deInfoBox": {"title": "Hinweis","msg": "Info box body","url": "https://www.bag.admin.ch/","urlTitle": "Weitere Informationen"},"frInfoBox": null,"itInfoBox": null,"enInfoBox": null,"ptInfoBox": null,"esInfoBox": null,"sqInfoBox": null,"bsInfoBox": null,"hrInfoBox": null,"srInfoBox": null,"rmInfoBox": null},"sdkConfig": {"numberOfWindowsForExposure": 3,"eventThreshold": 0.8,"badAttenuationThreshold": 73,"contactAttenuationThreshold": 73},"iOSGaenSdkConfig": {"lowerThreshold": 53,"higherThreshold": 60,"factorLow": 1,"factorHigh": 0.5,"triggerThreshold": 15},"androidGaenSdkConfig": {"lowerThreshold": 53,"higherThreshold": 60,"factorLow": 1,"factorHigh": 0.5,"triggerThreshold": 15}}
+        """
+        let config = try! JSONDecoder().decode(ConfigResponseBody.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(config.forceUpdate, false)
+        XCTAssertEqual(config.infoBox?.value(for: "de")?.title, "Hinweis")
+        XCTAssertEqual(config.infoBox?.value(for: "de")?.msg, "Info box body")
+        XCTAssertEqual(config.infoBox?.value(for: "de")?.url?.absoluteString, "https://www.bag.admin.ch/")
+        XCTAssertEqual(config.infoBox?.value(for: "de")?.urlTitle, "Weitere Informationen")
+
+        XCTAssertNil(config.infoBox?.value(for: "fr"))
+        XCTAssertNil(config.infoBox?.value(for: "it"))
+        XCTAssertNil(config.infoBox?.value(for: "en"))
+        XCTAssertNil(config.infoBox?.value(for: "pt"))
+        XCTAssertNil(config.infoBox?.value(for: "es"))
+        XCTAssertNil(config.infoBox?.value(for: "sq"))
+        XCTAssertNil(config.infoBox?.value(for: "bs"))
+        XCTAssertNil(config.infoBox?.value(for: "hr"))
+        XCTAssertNil(config.infoBox?.value(for: "sr"))
+        XCTAssertNil(config.infoBox?.value(for: "rm"))
+
+        XCTAssertEqual(config.iOSGaenSdkConfig?.factorHigh, 0.5)
+        XCTAssertEqual(config.iOSGaenSdkConfig?.lowerThreshold, 53)
+        XCTAssertEqual(config.iOSGaenSdkConfig?.higherThreshold, 60)
+        XCTAssertEqual(config.iOSGaenSdkConfig?.factorLow, 1)
+        XCTAssertEqual(config.iOSGaenSdkConfig?.triggerThreshold, 15)
+    }
+}


### PR DESCRIPTION
This PR changes the bahavior of the Infobox coming from the config request:
- It now uses "language_key".ub_localized to determine which language should be displayed.
- A bug was resolved which forced the infobox to contain a link otherwise the layout was broken.
- The LocalizedValue struct now correctly handles null values and does not fail parsing the whole object.
- Adds unit test for config parsing