### PR TITLE
Tracing disabled alert changes

### DIFF
--- a/DP3TApp/Screens/Homescreen/BegegnungenDetail/NSBluetoothSettingsControl.swift
+++ b/DP3TApp/Screens/Homescreen/BegegnungenDetail/NSBluetoothSettingsControl.swift
@@ -57,7 +57,7 @@ class NSBluetoothSettingsControl: UIView {
 
     private let tracingActiveWrapper = UIStackView()
 
-    private lazy var tracingErrorView = NSTracingErrorView.tracingErrorView(for: state.tracing) ?? NSTracingErrorView(model: NSTracingErrorView.NSTracingErrorViewModel(icon: UIImage(), title: "", text: "", buttonTitle: nil, action: nil))
+    private lazy var tracingErrorView = NSTracingErrorView.tracingErrorView(for: state.tracing, isHomeScreen: false) ?? NSTracingErrorView(model: NSTracingErrorView.NSTracingErrorViewModel(icon: UIImage(), title: "", text: "", buttonTitle: nil, action: nil))
 
     var activeViewConstraint: Constraint?
     var inactiveViewConstraint: Constraint?
@@ -163,7 +163,7 @@ class NSBluetoothSettingsControl: UIView {
         self.state = state.begegnungenDetail
 
         switchControl.setOn(state.begegnungenDetail.tracingEnabled, animated: false)
-        tracingErrorView.model = NSTracingErrorView.model(for: state.begegnungenDetail.tracing)
+        tracingErrorView.model = NSTracingErrorView.model(for: state.begegnungenDetail.tracing, isHomeScreen: false)
 
         switch state.begegnungenDetail.tracing {
         case .tracingActive:

--- a/DP3TApp/Screens/Homescreen/Homescreen/Begegnungen/NSBegegnungenModuleView.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/Begegnungen/NSBegegnungenModuleView.swift
@@ -62,7 +62,7 @@ class NSBegegnungenModuleView: NSModuleBaseView {
     }()
 
     private var tracingErrorView: NSTracingErrorView? {
-        NSTracingErrorView.tracingErrorView(for: uiState)
+        NSTracingErrorView.tracingErrorView(for: uiState, isHomeScreen: true)
     }
 
     override init() {

--- a/DP3TApp/Screens/Homescreen/Homescreen/NSHomescreenViewController.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/NSHomescreenViewController.swift
@@ -236,7 +236,7 @@ class NSHomescreenViewController: NSTitleViewScrollViewController {
     func updateState(_ state: UIStateModel) {
         appTitleView.uiState = state.homescreen.header
         handshakesModuleView.uiState = state.homescreen.begegnungen
-        meldungView.uiState = state.homescreen.meldungen
+        meldungView.uiState = state.homescreen
 
         let isInfected = state.homescreen.meldungen.meldung == .infected
         whatToDoSymptomsButton.isHidden = isInfected

--- a/DP3TApp/SharedUI/Views/NSTracingErrorView.swift
+++ b/DP3TApp/SharedUI/Views/NSTracingErrorView.swift
@@ -124,22 +124,32 @@ class NSTracingErrorView: UIView {
 
     // MARK: - Factory
 
-    static func tracingErrorView(for state: UIStateModel.TracingState) -> NSTracingErrorView? {
-        if let model = self.model(for: state) {
+    static func tracingErrorView(for state: UIStateModel.TracingState, isHomeScreen: Bool) -> NSTracingErrorView? {
+        if let model = self.model(for: state, isHomeScreen: isHomeScreen) {
             return NSTracingErrorView(model: model)
         }
 
         return nil
     }
 
-    static func model(for state: UIStateModel.TracingState) -> NSTracingErrorViewModel? {
+    static func model(for state: UIStateModel.TracingState, isHomeScreen: Bool) -> NSTracingErrorViewModel? {
         switch state {
         case .tracingDisabled:
-            return NSTracingErrorViewModel(icon: UIImage(named: "ic-error")!,
-                                           title: "tracing_turned_off_title".ub_localized,
-                                           text: "tracing_turned_off_text".ub_localized,
-                                           buttonTitle: nil,
-                                           action: nil)
+            if isHomeScreen {
+                return NSTracingErrorViewModel(icon: UIImage(named: "ic-error")!,
+                                               title: "tracing_turned_off_title".ub_localized,
+                                               text: "tracing_turned_off_text".ub_localized,
+                                               buttonTitle: "activate_tracing_button".ub_localized,
+                                               action: { _ in
+                                                   TracingManager.shared.isActivated = true
+                                               })
+            } else {
+                return NSTracingErrorViewModel(icon: UIImage(named: "ic-error")!,
+                                               title: "tracing_turned_off_title".ub_localized,
+                                               text: "tracing_turned_off_detailed_text".ub_localized,
+                                               buttonTitle: nil,
+                                               action: nil)
+            }
         case let .tracingPermissionError(code):
             return NSTracingErrorViewModel(icon: UIImage(named: "ic-bluetooth-disabled")!,
                                            title: "tracing_permission_error_title_ios".ub_localized,

--- a/Translations/bs.lproj/Localizable.strings
+++ b/Translations/bs.lproj/Localizable.strings
@@ -911,3 +911,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Aktiviraj praćenje";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -533,7 +533,7 @@
 
 /*Fehler: Standortinformationen / Bluetooth*/
 /*Fuzzy*/
-"android_foreground_service_notification_error_location_service" = "Schalten Sie die Standortinformation ein, damit die App Bluetooth nützen kann. Die App kennt zu keinem Zeitpunkt Ihren Ort.";
+"android_foreground_service_notification_error_location_service" = "Bei Android-Geräten ist Bluetooth an die Freigabe des Standorts gekoppelt. Deshalb muss die Standort-Funktion aktiviert werden, auch wenn die App zu keinem Zeitpunkt auf Ihren Standort zugreift.";
 
 /*Location Services ausgeschaltet Titel*/
 /*Fuzzy*/
@@ -918,3 +918,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "Die Infoline SwissCovid berät Sie über die Möglichkeit eines kostenlosen Corona Tests.";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Tracing aktivieren";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "Aktivieren Sie das Tracing, damit die App Begegnungen speichern und Meldungen empfangen kann.";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "Wenn das Tracing deaktiviert ist, können auch keine Meldungen empfangen werden.";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "Hinweis";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "Datenschutzerklärung";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "Nutzungsbedingungen";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -901,3 +901,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Activate proximity tracing";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/es.lproj/Localizable.strings
+++ b/Translations/es.lproj/Localizable.strings
@@ -894,3 +894,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Activar el rastreo";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/fr.lproj/Localizable.strings
+++ b/Translations/fr.lproj/Localizable.strings
@@ -909,3 +909,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Activer le traçage de proximité";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/hr.lproj/Localizable.strings
+++ b/Translations/hr.lproj/Localizable.strings
@@ -894,3 +894,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Aktiviraj praćenje";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/it.lproj/Localizable.strings
+++ b/Translations/it.lproj/Localizable.strings
@@ -903,3 +903,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Attivare il tracciamento";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/pt.lproj/Localizable.strings
+++ b/Translations/pt.lproj/Localizable.strings
@@ -894,3 +894,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Ativar o rastreamento";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/rm.lproj/Localizable.strings
+++ b/Translations/rm.lproj/Localizable.strings
@@ -896,3 +896,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Activar tracing";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/sq.lproj/Localizable.strings
+++ b/Translations/sq.lproj/Localizable.strings
@@ -894,3 +894,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Aktivizo gjurmimin";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/sr-Latn-RS.lproj/Localizable.strings
+++ b/Translations/sr-Latn-RS.lproj/Localizable.strings
@@ -894,3 +894,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Aktiviraj praćenje";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/ti.lproj/Localizable.strings
+++ b/Translations/ti.lproj/Localizable.strings
@@ -890,3 +890,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "ኣገልግሎት ምክትታል ከም ዝሰርሕ ግበርዎ (ወልዕዎ)";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";

--- a/Translations/tr.lproj/Localizable.strings
+++ b/Translations/tr.lproj/Localizable.strings
@@ -890,3 +890,21 @@
 
 /*Meldungen Detail Kostenloser Test Box Text*/
 "meldungen_detail_free_test_text" = "";
+
+/*Button title on the Home Screen when the Tracing is deactivated to directly activate it.*/
+"activate_tracing_button" = "Takibi etkinleştir";
+
+/*Detailed Version of tracing_turned_off_text that is displayed to the user in the Tracing Detail View when the Tracing is deactivated.*/
+"tracing_turned_off_detailed_text" = "";
+
+/*Warning that is displayed to the user in the Home View under the Meldungen-Card.*/
+"meldungen_tracing_not_active_warning" = "";
+
+/*Warning title for Meldungen-Card when Tracing is turned off.*/
+"meldungen_tracing_turned_off_title" = "";
+
+/*Data Protection Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_data_protection_statement" = "";
+
+/*Conditions of Use Header String in Onboarding Disclaimer View.*/
+"onboarding_disclaimer_conditions_of_use" = "";


### PR DESCRIPTION
- text was changed on detail page
- it is indicated to the user that sync is not happening while en is turned off
- there is a CTA to activate tracing on the homescreen