### PR TITLE
disable editing interaction when entering a covidCode

### DIFF
--- a/DP3TApp/Screens/Homescreen/InformBroadcast/CodeInput/NSCodeInputControl.swift
+++ b/DP3TApp/Screens/Homescreen/InformBroadcast/CodeInput/NSCodeInputControl.swift
@@ -211,6 +211,7 @@ class NSCodeSingleControl: UIView, UITextFieldDelegate {
         accessibilityTraits = .staticText
         isAccessibilityElement = true
         textField.isAccessibilityElement = false
+        textField.disableEditionInteraction = true
     }
 
     override var accessibilityLabel: String? {
@@ -357,6 +358,8 @@ class NSCodeSingleControl: UIView, UITextFieldDelegate {
 class NSTextField: UITextField {
     public weak var singleControl: NSCodeSingleControl?
 
+    public var disableEditionInteraction = false
+
     override func paste(_: Any?) {
         let pasteboard = UIPasteboard.general
 
@@ -367,5 +370,12 @@ class NSTextField: UITextField {
 
     override func canPerformAction(_ action: Selector, withSender _: Any?) -> Bool {
         return action == #selector(UIResponderStandardEditActions.paste)
+    }
+
+    override var editingInteractionConfiguration: UIEditingInteractionConfiguration {
+        if disableEditionInteraction {
+            return .none
+        }
+        return super.editingInteractionConfiguration
     }
 }

--- a/DP3TApp/Screens/Onboarding/NSOnboardingDisclaimerViewController.swift
+++ b/DP3TApp/Screens/Onboarding/NSOnboardingDisclaimerViewController.swift
@@ -66,7 +66,6 @@ class NSOnboardingDisclaimerViewController: NSOnboardingContentViewController {
             make.leading.trailing.equalTo(self.stackScrollView.stackView).inset(NSPadding.large)
         }
 
-
         privacyButton.title = "onboarding_disclaimer_to_online_version_button".ub_localized
         privacyButton.touchUpCallback = { [weak self] in
             self?.openPrivacyLink()


### PR DESCRIPTION
since this was leading to a crash when tapping with three fingers on the keyboard and then selecting undo