### PR TITLE
sync notifications

### DIFF
--- a/DP3TApp/Logic/AppDelegate.swift
+++ b/DP3TApp/Logic/AppDelegate.swift
@@ -36,6 +36,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // defer window initialization if app was launched in
         // background because of location change
         if shouldSetupWindow(application: application, launchOptions: launchOptions) {
+            TracingLocalPush.shared.resetBackgroundTaskWarningTriggers()
             setupWindow()
             willAppearAfterColdstart(application, coldStart: true, backgroundTime: 0)
         }

--- a/DP3TApp/Logic/Tracing/DatabaseSyncer.swift
+++ b/DP3TApp/Logic/Tracing/DatabaseSyncer.swift
@@ -138,8 +138,7 @@ class DatabaseSyncer {
                     UIStateManager.shared.syncError = nil
                 }
 
-                // wait another 2 days befor warning
-                TracingLocalPush.shared.resetSyncWarningTriggers(lastSuccess: Date())
+                TracingLocalPush.shared.resetBackgroundTaskWarningTriggers()
 
                 // reload status, user could have been exposed
                 TracingManager.shared.updateStatus(completion: nil)

--- a/DP3TApp/Logic/Tracing/DatabaseSyncer.swift
+++ b/DP3TApp/Logic/Tracing/DatabaseSyncer.swift
@@ -146,6 +146,9 @@ class DatabaseSyncer {
                 NotificationCenter.default.post(name: Notification.syncFinishedNotification, object: nil)
                 completionHandler?(.newData)
             }
+
+            TracingLocalPush.shared.handleSync(result: result)
+
             if taskIdentifier != .invalid {
                 UIApplication.shared.endBackgroundTask(taskIdentifier)
                 taskIdentifier = .invalid

--- a/DP3TApp/Logic/Tracing/TracingLocalPush.swift
+++ b/DP3TApp/Logic/Tracing/TracingLocalPush.swift
@@ -130,27 +130,16 @@ class TracingLocalPush: NSObject {
         center.removePendingNotificationRequests(withIdentifiers: [notificationIdentifier1, notificationIdentifier2])
     }
 
-    func resetSyncWarningTriggers(tracingState: TracingState) {
-        if TracingManager.shared.isActivated {
-            if let lastSync = tracingState.lastSync {
-                resetSyncWarningTriggers(lastSuccess: lastSync)
-            }
-        } else {
-            removeSyncWarningTriggers()
-        }
-    }
-
-    func resetSyncWarningTriggers(lastSuccess: Date) {
+    /// This method gets called everytime we get executed in the backgrund or if the app was launched manually
+    func resetBackgroundTaskWarningTriggers() {
         let content = UNMutableNotificationContent()
         content.title = "sync_warning_notification_title".ub_localized
         content.body = "sync_warning_notification_text".ub_localized
 
-        let timePassed = lastSuccess.timeIntervalSinceNow
-
-        let trigger1 = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval1 - timePassed, repeats: false)
+        let trigger1 = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval1, repeats: false)
         let request1 = UNNotificationRequest(identifier: notificationIdentifier1, content: content, trigger: trigger1)
 
-        let trigger2 = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval2 - timePassed, repeats: false)
+        let trigger2 = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval2, repeats: false)
         let request2 = UNNotificationRequest(identifier: notificationIdentifier2, content: content, trigger: trigger2)
 
         // Adding a request with the same identifier again automatically cancels an existing request with that identifier, if present

--- a/DP3TApp/Logic/Tracing/TracingLocalPush.swift
+++ b/DP3TApp/Logic/Tracing/TracingLocalPush.swift
@@ -117,8 +117,17 @@ class TracingLocalPush: NSObject {
 
     // MARK: - Sync warnings
 
-    // If sync doesnt work for 2 days, we show a notification
-    // User should open app to fix issues
+    // 1: If the background tak doesnt work for 2 days we show a notification
+    //    User should open app to fix issues
+
+    private func scheduleSyncWarningNotification(delay: TimeInterval, identifier: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "sync_warning_notification_title".ub_localized
+        content.body = "sync_warning_notification_text".ub_localized
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: delay, repeats: false)
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+        center.add(request, withCompletionHandler: nil)
+    }
 
     private let notificationIdentifier1 = "ch.admin.bag.notification.syncWarning1"
     private let notificationIdentifier2 = "ch.admin.bag.notification.syncWarning2"
@@ -127,24 +136,31 @@ class TracingLocalPush: NSObject {
     private let timeInterval2: TimeInterval = 60 * 60 * 24 * 7 // Seven days
 
     func removeSyncWarningTriggers() {
-        center.removePendingNotificationRequests(withIdentifiers: [notificationIdentifier1, notificationIdentifier2])
+        center.removePendingNotificationRequests(withIdentifiers: [notificationIdentifier1, notificationIdentifier2, syncErrorNotificationIdentifier])
     }
 
-    /// This method gets called everytime we get executed in the backgrund or if the app was launched manually
+    // This method gets called everytime we get executed in the backgrund or if the app was launched manually
     func resetBackgroundTaskWarningTriggers() {
-        let content = UNMutableNotificationContent()
-        content.title = "sync_warning_notification_title".ub_localized
-        content.body = "sync_warning_notification_text".ub_localized
-
-        let trigger1 = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval1, repeats: false)
-        let request1 = UNNotificationRequest(identifier: notificationIdentifier1, content: content, trigger: trigger1)
-
-        let trigger2 = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval2, repeats: false)
-        let request2 = UNNotificationRequest(identifier: notificationIdentifier2, content: content, trigger: trigger2)
-
         // Adding a request with the same identifier again automatically cancels an existing request with that identifier, if present
-        center.add(request1, withCompletionHandler: nil)
-        center.add(request2, withCompletionHandler: nil)
+        scheduleSyncWarningNotification(delay: timeInterval1, identifier: notificationIdentifier1)
+        scheduleSyncWarningNotification(delay: timeInterval2, identifier: notificationIdentifier2)
+    }
+
+    // 1: If a error happens during sync we show a notification after 1 day
+    //    we cancel the notification if the error was resolved in the meantime
+
+    private let syncErrorNotificationIdentifier = "ch.admin.bag.notification.syncWarning1"
+    private let syncErrorNotificationDelay: TimeInterval = 60 * 60 * 24 * 1 // One days
+
+    func handleSync(result: SyncResult) {
+        switch result {
+        case .failure:
+            scheduleSyncWarningNotification(delay: syncErrorNotificationDelay, identifier: syncErrorNotificationIdentifier)
+        case .success:
+            center.removePendingNotificationRequests(withIdentifiers: [syncErrorNotificationIdentifier])
+        case .skipped:
+            break
+        }
     }
 
     func handleTracingState(_ state: DP3TSDK.TrackingState) {

--- a/DP3TApp/Logic/Tracing/TracingManager.swift
+++ b/DP3TApp/Logic/Tracing/TracingManager.swift
@@ -200,7 +200,6 @@ class TracingManager: NSObject {
 
                 // schedule local push if exposed
                 TracingLocalPush.shared.update(provider: st)
-                TracingLocalPush.shared.resetSyncWarningTriggers(tracingState: st)
             }
             DP3TTracing.delegate = self
         }
@@ -218,8 +217,6 @@ extension TracingManager: DP3TTracingDelegate {
                 UIStateManager.shared.tracingState = state
                 UIStateManager.shared.trackingState = state.trackingState
             }
-            TracingLocalPush.shared.update(provider: state)
-            TracingLocalPush.shared.resetSyncWarningTriggers(tracingState: state)
         }
     }
 }
@@ -242,6 +239,9 @@ extension TracingManager: DP3TBackgroundHandler {
             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
             center.add(request)
         #endif
+
+        // wait another 2 days befor warning
+        TracingLocalPush.shared.resetBackgroundTaskWarningTriggers()
 
         let queue = OperationQueue()
 

--- a/DP3TAppTests/TracingLocalPushTests.swift
+++ b/DP3TAppTests/TracingLocalPushTests.swift
@@ -26,6 +26,22 @@ class TracingLocalPushTests: XCTestCase {
         tlp = TracingLocalPush(notificationCenter: center, keychain: keychain)
     }
 
+    func testBackgroundTaskWarning() {
+        let referenceDate = Date()
+        tlp.resetBackgroundTaskWarningTriggers()
+        XCTAssertEqual(center.requests.count, 2)
+
+        let first = center.requests[0]
+        let firstTimetrigger = first.trigger as! UNTimeIntervalNotificationTrigger
+
+        let second = center.requests[1]
+        let secondTimeTrigger = second.trigger as! UNTimeIntervalNotificationTrigger
+
+        let dates = [firstTimetrigger.nextTriggerDate()!, secondTimeTrigger.nextTriggerDate()!].sorted()
+        XCTAssertEqual(Int(dates[0].timeIntervalSince1970), Int(referenceDate.addingTimeInterval(60 * 60 * 24 * 2).timeIntervalSince1970))
+        XCTAssertEqual(Int(dates[1].timeIntervalSince1970), Int(referenceDate.addingTimeInterval(60 * 60 * 24 * 7).timeIntervalSince1970))
+    }
+
     func testRemovingNotification() {
         tlp.clearNotifications()
         XCTAssertEqual(

--- a/DP3TAppTests/TracingLocalPushTests.swift
+++ b/DP3TAppTests/TracingLocalPushTests.swift
@@ -42,6 +42,22 @@ class TracingLocalPushTests: XCTestCase {
         XCTAssertEqual(Int(dates[1].timeIntervalSince1970), Int(referenceDate.addingTimeInterval(60 * 60 * 24 * 7).timeIntervalSince1970))
     }
 
+    func testSyncErrorNotification() {
+        let referenceDate = Date()
+        tlp.handleSync(result: .failure(.permissonError))
+
+        XCTAssertEqual(center.requests.count, 1)
+
+        let request = center.requests.first!
+        let trigger = request.trigger as! UNTimeIntervalNotificationTrigger
+
+        XCTAssertEqual(Int(trigger.nextTriggerDate()!.timeIntervalSince(referenceDate)), 60 * 60 * 24)
+
+        tlp.handleSync(result: .success)
+
+        XCTAssertEqual(center.requests.count, 0)
+    }
+
     func testRemovingNotification() {
         tlp.clearNotifications()
         XCTAssertEqual(


### PR DESCRIPTION
improves sync error notification:

- one type is re-scheduled with every background task execution
- if an error happens during sync a notification is scheduled for 24h