### PR TITLE
improves background refresh error message

### DIFF
--- a/DP3TApp/Screens/Homescreen/Homescreen/Reports/NSReportsModuleView.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/Reports/NSReportsModuleView.swift
@@ -85,12 +85,7 @@ class NSReportsModuleView: NSModuleBaseView {
         }
     }))
 
-    private let backgroundFetchProblemView = NSTracingErrorView(model: NSTracingErrorView.NSTracingErrorViewModel(icon: UIImage(named: "ic-refresh")!, title: "meldungen_background_error_title".ub_localized, text: "meldungen_background_error_text".ub_localized, buttonTitle: "meldungen_background_error_button".ub_localized, action: { _ in
-        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString),
-            UIApplication.shared.canOpenURL(settingsUrl) else { return }
-
-        UIApplication.shared.open(settingsUrl)
-    }))
+    private let backgroundFetchProblemView = NSTracingErrorView(model: NSTracingErrorView.NSTracingErrorViewModel(icon: UIImage(named: "ic-refresh")!, title: "meldungen_background_error_title".ub_localized, text: "meldungen_background_error_text".ub_localized, buttonTitle: nil, action: nil))
 
     override init() {
         super.init()

--- a/Translations/bs.lproj/Localizable.strings
+++ b/Translations/bs.lproj/Localizable.strings
@@ -454,7 +454,7 @@
 "meldungen_background_error_title" = "Ažuriranje pozadine isključeno";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Promenite podešavanja da biste dobijali obaveštenja o novoj poruci takođe i izvan aplikacije.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Promeni podešavanja";

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -462,7 +462,7 @@
 "meldungen_background_error_title" = "Hintergrundaktualisierung ausgeschaltet";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Ändern Sie die Einstellungen, um bei einer neuen Meldung auch ausserhalb der App informiert zu werden.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Einstellungen ändern";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -454,7 +454,7 @@
 "meldungen_background_error_title" = "Background update deactivated.";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Change the settings to receive notification outside the app as well in the event of a report.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Change settings";

--- a/Translations/es.lproj/Localizable.strings
+++ b/Translations/es.lproj/Localizable.strings
@@ -454,7 +454,7 @@
 "meldungen_background_error_title" = "Actualización de fondo desactivada";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Cambie los ajustes para recibir las notificaciones más actuales también fuera de la aplicación.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Cambiar ajustes";

--- a/Translations/fr.lproj/Localizable.strings
+++ b/Translations/fr.lproj/Localizable.strings
@@ -454,7 +454,7 @@
 "meldungen_background_error_title" = "Actualisation de l'arrière-plan désactivée";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Veuillez modifier les paramètres pour pouvoir recevoir les nouvelles notifications même en dehors de l'application.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Modifier les paramètres";

--- a/Translations/hr.lproj/Localizable.strings
+++ b/Translations/hr.lproj/Localizable.strings
@@ -453,7 +453,7 @@
 "meldungen_background_error_title" = "Ažuriranje pozadine isključeno";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Promenite podešavanja da biste dobijali obaveštenja o novoj poruci takođe i izvan aplikacije.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Promeni podešavanja";

--- a/Translations/it.lproj/Localizable.strings
+++ b/Translations/it.lproj/Localizable.strings
@@ -454,7 +454,7 @@
 "meldungen_background_error_title" = "Aggiornamento in background disattivato";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Modifica le impostazioni per essere informato anche al di fuori dell'app in caso di nuova segnalazione.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Modifica impostazioni";

--- a/Translations/pt.lproj/Localizable.strings
+++ b/Translations/pt.lproj/Localizable.strings
@@ -454,7 +454,7 @@
 "meldungen_background_error_title" = "Atualização em segundo plano desligada";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Altere as definições para receber as notificações também fora da app.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Alterar as definições";

--- a/Translations/rm.lproj/Localizable.strings
+++ b/Translations/rm.lproj/Localizable.strings
@@ -454,7 +454,7 @@
 "meldungen_background_error_title" = "Actualisaziun dal fund messa ord funcziun";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Midai la configuraziun per esser infurmà/infurmada tar ina nova communicaziun er ordaifer l'app.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Midar confguraziun";

--- a/Translations/sq.lproj/Localizable.strings
+++ b/Translations/sq.lproj/Localizable.strings
@@ -454,7 +454,7 @@
 "meldungen_background_error_title" = "Përditësimi në sfond i fikur";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Ndryshoni cilësimet, për t'u informuar për një mesazh të ri edhe jashtë aplikacionit.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Ndrysho cilësimet";

--- a/Translations/sr-Latn-RS.lproj/Localizable.strings
+++ b/Translations/sr-Latn-RS.lproj/Localizable.strings
@@ -453,7 +453,7 @@
 "meldungen_background_error_title" = "Ažuriranje pozadine isključeno";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Promenite podešavanja da biste dobijali obaveštenja o novoj poruci takođe i izvan aplikacije.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Promeni podešavanja";

--- a/Translations/ti.lproj/Localizable.strings
+++ b/Translations/ti.lproj/Localizable.strings
@@ -453,7 +453,7 @@
 "meldungen_background_error_title" = "ድሕረባይታ እዋናዊ ንምግባር ኣገልግሎት የለን (ጠፊኡ ኣሎ)።";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "ሓድሽ ሓበሬታ ምስዝህሉ: ካብቲ ኣፕ ወጻኢ ውን ንኽትሕበሩ ምእንታን: ነቲ ሴቲንግ ቀይርዎ። ";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "ሴቲንግ ምቕያር ";

--- a/Translations/tr.lproj/Localizable.strings
+++ b/Translations/tr.lproj/Localizable.strings
@@ -453,7 +453,7 @@
 "meldungen_background_error_title" = "Arka plan güncellemesi kapatıldı";
 
 /*Text für Hintergrund Fehler*/
-"meldungen_background_error_text" = "Uygulama açık olmadığında da bildirim alabilmek için lütfen ayarları değiştirin.";
+"meldungen_background_error_text" = "\"Go to \"Settings -> General > Background App Refresh\" and make sure “Wi-Fi & Mobile Data” is selected. Background App Refresh can then be disabled for each app individually. \"";
 
 /*Button Titel für Hintergrundfehler beheben*/
 "meldungen_background_error_button" = "Ayarları değiştirin";


### PR DESCRIPTION
When background refresh is not available we were showing a button to go to the app-specific settings inside the settings.app. For some users, the issue was that background refresh was disabled globally, therefore we now show an instruction to resolve the issue and remove the button. Translations will follow.