### PR TITLE
fixes quarantine countdown

### DIFF
--- a/DP3TApp/Screens/Reports/NSReportsDetailReportViewController.swift
+++ b/DP3TApp/Screens/Reports/NSReportsDetailReportViewController.swift
@@ -116,8 +116,14 @@ class NSReportsDetailReportViewController: NSTitleViewScrollViewController {
             callLabels.forEach {
                 $0.text = "meldungen_detail_call_last_call".ub_localized.replacingOccurrences(of: "{DATE}", with: DateFormatter.ub_string(from: lastCall))
             }
-            daysLeftLabels.forEach {
-                $0.text = DateFormatter.ub_inDays(until: lastCall.addingTimeInterval(60 * 60 * 24 * 10)) // 10 days after last exposure
+            let quarantinePeriod: TimeInterval = 60 * 60 * 24 * 10
+            if let latestExposure: Date = reports.map(\.timestamp).sorted(by: >).first {
+                let endQuarentineDate = latestExposure.addingTimeInterval(quarantinePeriod)
+                if endQuarentineDate.timeIntervalSinceNow > 0 {
+                    daysLeftLabels.forEach {
+                        $0.text = DateFormatter.ub_inDays(until: endQuarentineDate)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
The quarantine countdown is shown as soon as the call button is pressed at least once.
Until now the countdown was based on the last call timestamp, this PR shows the quarantine countdown based on the latest exposure date.