### PR TITLE
Adds info view for users without code

### DIFF
--- a/DP3TApp/Screens/WhatToDo/NSWhatToDoPositiveTestViewController.swift
+++ b/DP3TApp/Screens/WhatToDo/NSWhatToDoPositiveTestViewController.swift
@@ -91,6 +91,18 @@ class NSWhatToDoPositiveTestViewController: NSViewController {
 
         stackScrollView.addSpacerView(2.0 * NSPadding.medium)
 
+        stackScrollView.addArrangedView(NSOnboardingInfoView(icon: UIImage(named: "ic-call")!, text: "inform_detail_faq_nocode_text".ub_localized, title: "inform_detail_faq_nocode_title".ub_localized, leftRightInset: 0, dynamicIconTintColor: .ns_purple))
+
+        let callButton = NSExternalLinkButton(style: .normal(color: .ns_purple))
+        callButton.title = "infoline_coronavirus_number".ub_localized
+        callButton.touchUpCallback = { [weak self] in
+            self?.callButtonTouched()
+        }
+        callButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: NSPadding.large + NSPadding.medium, bottom: 0, right: 0)
+        stackScrollView.addArrangedView(callButton)
+
+        stackScrollView.addSpacerView(2.0 * NSPadding.medium)
+
         stackScrollView.addArrangedView(NSOnboardingInfoView(icon: UIImage(named: "ic-key-purple")!, text: "inform_detail_faq2_text".ub_localized, title: "inform_detail_faq2_title".ub_localized, leftRightInset: 0, dynamicIconTintColor: .ns_purple))
 
         stackScrollView.addSpacerView(2.0 * NSPadding.medium)
@@ -102,6 +114,11 @@ class NSWhatToDoPositiveTestViewController: NSViewController {
         stackScrollView.addArrangedView(NSButton.faqButton(color: .ns_purple))
 
         stackScrollView.addSpacerView(NSPadding.large)
+    }
+
+    private func callButtonTouched() {
+        let phoneNumber = "infoline_coronavirus_number".ub_localized
+        PhoneCallHelper.call(phoneNumber)
     }
 
     private func setupAccessibility() {

--- a/Translations/bs.lproj/Localizable.strings
+++ b/Translations/bs.lproj/Localizable.strings
@@ -918,3 +918,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Promenite podešavanja da biste dobijali obaveštenja o novoj poruci takođe i izvan aplikacije.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -944,3 +944,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Ändern Sie die Einstellungen, um bei einer neuen Meldung auch ausserhalb der App informiert zu werden.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "Wie finde ich den Covidcode?";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "Sie wurden positiv getestet und können Ihren Code nicht finden? Dann kontaktieren Sie die Infoline Coronavirus:";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "+41 58 463 00 00";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -923,3 +923,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Change the settings to receive notification outside the app as well in the event of a report.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/es.lproj/Localizable.strings
+++ b/Translations/es.lproj/Localizable.strings
@@ -918,3 +918,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Cambie los ajustes para recibir las notificaciones más actuales también fuera de la aplicación.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/fr.lproj/Localizable.strings
+++ b/Translations/fr.lproj/Localizable.strings
@@ -925,3 +925,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Veuillez modifier les paramètres pour pouvoir recevoir les nouvelles notifications même en dehors de l'application.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/hr.lproj/Localizable.strings
+++ b/Translations/hr.lproj/Localizable.strings
@@ -914,3 +914,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Promenite podešavanja da biste dobijali obaveštenja o novoj poruci takođe i izvan aplikacije.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/it.lproj/Localizable.strings
+++ b/Translations/it.lproj/Localizable.strings
@@ -925,3 +925,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Modifica le impostazioni per essere informato anche al di fuori dell'app in caso di nuova segnalazione.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/pt.lproj/Localizable.strings
+++ b/Translations/pt.lproj/Localizable.strings
@@ -918,3 +918,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Altere as definições para receber as notificações também fora da app.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/rm.lproj/Localizable.strings
+++ b/Translations/rm.lproj/Localizable.strings
@@ -914,3 +914,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Midai la configuraziun per esser infurmà/infurmada tar ina nova communicaziun er ordaifer l'app.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/sq.lproj/Localizable.strings
+++ b/Translations/sq.lproj/Localizable.strings
@@ -918,3 +918,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Ndryshoni cilësimet, për t'u informuar për një mesazh të ri edhe jashtë aplikacionit.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/sr-Latn-RS.lproj/Localizable.strings
+++ b/Translations/sr-Latn-RS.lproj/Localizable.strings
@@ -914,3 +914,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Promenite podešavanja da biste dobijali obaveštenja o novoj poruci takođe i izvan aplikacije.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/ti.lproj/Localizable.strings
+++ b/Translations/ti.lproj/Localizable.strings
@@ -914,3 +914,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "ሓድሽ ሓበሬታ ምስዝህሉ: ካብቲ ኣፕ ወጻኢ ውን ንኽትሕበሩ ምእንታን: ነቲ ሴቲንግ ቀይርዎ።";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";

--- a/Translations/tr.lproj/Localizable.strings
+++ b/Translations/tr.lproj/Localizable.strings
@@ -914,3 +914,12 @@
 
 /*Text für Hintergrundfehler auf Android*/
 "meldungen_background_error_text_android" = "Uygulama açık olmadığında da bildirim alabilmek için lütfen ayarları değiştirin.";
+
+/*Informieren Detail: FAQ Titel*/
+"inform_detail_faq_nocode_title" = "";
+
+/*Inform Detail: FAQ Text*/
+"inform_detail_faq_nocode_text" = "";
+
+/*Telefonnummer der allgemeinen Infoline Coronavirus*/
+"infoline_coronavirus_number" = "";


### PR DESCRIPTION
This PR adds an information view to the positive testes view. This points users to the helpline in case they did not get a code with their positive test.