### PR TITLE
iOS version specific setting text

### DIFF
--- a/DP3TApp/Logic/Tracing/TracingLocalPush.swift
+++ b/DP3TApp/Logic/Tracing/TracingLocalPush.swift
@@ -193,8 +193,8 @@ class TracingLocalPush: NSObject {
 
     private func schedulePermissonErrorNotification() {
         scheduleErrorNotification(identifier: .permission,
-                                  title: "tracing_permission_error_title_ios".ub_localized,
-                                  text: "tracing_permission_error_text_ios".ub_localized)
+                                  title: "tracing_permission_error_title_ios".ub_localized.replaceSettingsString,
+                                  text: "tracing_permission_error_text_ios".ub_localized.replaceSettingsString)
     }
 
     private func handleENError(_ error: ENError) {

--- a/DP3TApp/Screens/Homescreen/EncountersDetail/NSBluetoothSettingsControl.swift
+++ b/DP3TApp/Screens/Homescreen/EncountersDetail/NSBluetoothSettingsControl.swift
@@ -73,7 +73,7 @@ class NSBluetoothSettingsControl: UIView {
         backgroundColor = .ns_moduleBackground
 
         titleLabel.text = "tracing_setting_title".ub_localized
-        subtitleLabel.text = "tracing_setting_text_ios".ub_localized
+        subtitleLabel.text = "tracing_setting_text_ios".ub_localized_per_version
         switchControl.onTintColor = .ns_blue
 
         setup()

--- a/DP3TApp/Screens/Onboarding/NSOnboardingPermissionsViewController.swift
+++ b/DP3TApp/Screens/Onboarding/NSOnboardingPermissionsViewController.swift
@@ -83,7 +83,7 @@ class NSOnboardingPermissionsViewController: NSOnboardingContentViewController {
         case .gapple:
             foregroundImageView.image = UIImage(named: "onboarding-bt-permission")!
             titleLabel.text = "onboarding_gaen_title".ub_localized
-            textLabel.text = "onboarding_gaen_text_ios".ub_localized
+            textLabel.text = "onboarding_gaen_text_ios".ub_localized.replaceSettingsString
             permissionButton.title = "onboarding_gaen_button_activate".ub_localized
 
             let info1 = NSOnboardingInfoView(icon: UIImage(named: "ic-encrypted")!, text: "onboarding_gaen_info_text_1".ub_localized, title: "onboarding_gaen_info_title_1".ub_localized, dynamicIconTintColor: .ns_blue)

--- a/DP3TApp/SharedUI/Helpers/String+NS.swift
+++ b/DP3TApp/SharedUI/Helpers/String+NS.swift
@@ -19,19 +19,7 @@ extension String {
         return localized
     }
 
-    private var ub_debugLocalized: String {
-        NSLocalizedString(self, tableName: "DebugStrings", comment: "")
-    }
-
-    static var languageKey: String {
-        "language_key".ub_localized
-    }
-
-    static var defaultLanguageKey: String {
-        "de"
-    }
-
-    var replaceSettingsString: String {
+    var ub_localized_per_version: String {
         var version = "14_0"
 
         switch UIDevice.current.systemVersion {
@@ -45,6 +33,32 @@ extension String {
             break
         }
 
-        return replacingOccurrences(of: "{TRACING_SETTING_TEXT}", with: "tracing_setting_text_ios_\(version)".ub_localized)
+        // Try to load version specific translation
+        var localized = NSLocalizedString("\(self)_\(version)", value: self, comment: "")
+        if localized == self {
+            // Fallback to general translation
+            localized = NSLocalizedString(self, comment: "")
+            if localized == self {
+                // Fallback to debug string
+                localized = ub_debugLocalized
+            }
+        }
+        return localized
+    }
+
+    private var ub_debugLocalized: String {
+        NSLocalizedString(self, tableName: "DebugStrings", comment: "")
+    }
+
+    static var languageKey: String {
+        "language_key".ub_localized
+    }
+
+    static var defaultLanguageKey: String {
+        "de"
+    }
+
+    var replaceSettingsString: String {
+        return replacingOccurrences(of: "{TRACING_SETTING_TEXT}", with: "tracing_setting_text_ios".ub_localized_per_version)
     }
 }

--- a/DP3TApp/SharedUI/Helpers/String+NS.swift
+++ b/DP3TApp/SharedUI/Helpers/String+NS.swift
@@ -30,4 +30,21 @@ extension String {
     static var defaultLanguageKey: String {
         "de"
     }
+
+    var replaceSettingsString: String {
+        var version = "14_0"
+
+        switch UIDevice.current.systemVersion {
+        case "13.5", "13.5.1":
+            version = "13_5"
+        case "13.6", "13.6.1":
+            version = "13_6"
+        case "14.0":
+            version = "14_0"
+        default:
+            break
+        }
+
+        return replacingOccurrences(of: "{TRACING_SETTING_TEXT}", with: "tracing_setting_text_ios_\(version)".ub_localized)
+    }
 }

--- a/DP3TApp/SharedUI/Helpers/String+NS.swift
+++ b/DP3TApp/SharedUI/Helpers/String+NS.swift
@@ -35,7 +35,7 @@ extension String {
 
         // Try to load version specific translation
         var localized = NSLocalizedString("\(self)_\(version)", value: self, comment: "")
-        if localized == self {
+        if localized == self || localized == "" {
             // Fallback to general translation
             localized = NSLocalizedString(self, comment: "")
             if localized == self {

--- a/DP3TApp/SharedUI/Views/NSTracingErrorView.swift
+++ b/DP3TApp/SharedUI/Views/NSTracingErrorView.swift
@@ -152,8 +152,8 @@ class NSTracingErrorView: UIView {
             }
         case let .tracingPermissionError(code):
             return NSTracingErrorViewModel(icon: UIImage(named: "ic-bluetooth-disabled")!,
-                                           title: "tracing_permission_error_title_ios".ub_localized,
-                                           text: "tracing_permission_error_text_ios".ub_localized,
+                                           title: "tracing_permission_error_title_ios".ub_localized.replaceSettingsString,
+                                           text: "tracing_permission_error_text_ios".ub_localized.replaceSettingsString,
                                            buttonTitle: "onboarding_gaen_button_activate".ub_localized,
                                            errorCode: code,
                                            action: { _ in

--- a/Translations/bs.lproj/Localizable.strings
+++ b/Translations/bs.lproj/Localizable.strings
@@ -921,3 +921,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/bs.lproj/Localizable.strings
+++ b/Translations/bs.lproj/Localizable.strings
@@ -929,4 +929,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Exposure Notifications";

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -952,8 +952,8 @@
 "tracing_setting_text_ios_13_5" = "COVID-19-Kontaktmitteilungen";
 
 /*Text beim Bluetooth Control iOS 13.6*/
-"tracing_setting_text_ios_13_6" = "COVID-19-Begegnungsaufzeichnungen";
+"tracing_setting_text_ios_13_6" = "COVID-19-Begegnungsmitteilungen";
 
 /*Text beim Bluetooth Control iOS 14*/
 /*Fuzzy*/
-"tracing_setting_text_ios_14_0" = "COVID-19-Begegnungsmeldungen";
+"tracing_setting_text_ios_14_0" = "Begegnungsmitteilungen";

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -640,7 +640,7 @@
 "symptom_faq1_title" = "Was sind COVID-19-Symptome?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Diese Symptome treten häufig auf:\n\n– Fieber, Fiebergefühl\n– Halsschmerzen\n– Husten (meist trocken)\n– Kurzatmigkeit\n– Muskelschmerzen\n– Plötzlicher Verlust des Geruchs- und oder Geschmackssinns";
+"symptom_faq1_text" = "Diese Symptome treten häufig auf:\n\n– Fieber, Fiebergefühl\n– Halsschmerzen\n– Husten (meist trocken)\n– Kurzatmigkeit\n– Muskelschmerzen\n– Plötzlicher Verlust des Geruchs- und/oder Geschmackssinns";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Warum ist das Tracing beendet?";
@@ -690,7 +690,7 @@
 
 /*Text auf der Onboarding Page für die Permission der Exposure-Library, iOS*/
 /*Fuzzy*/
-"onboarding_gaen_text_ios" = "Um die App nutzen zu können, müssen COVID-19-Kontaktmitteilungen aktiviert werden.";
+"onboarding_gaen_text_ios" = "Um die App nutzen zu können, müssen {TRACING_SETTING_TEXT} aktiviert werden.";
 
 /*Aktivieren-Button auf der Onboarding Page für die Permission der Exposure-Library*/
 "onboarding_gaen_button_activate" = "Aktivieren";
@@ -746,11 +746,11 @@
 
 /*Fehler-Titel, wenn Tracing deaktiviert wurde im System, iOS*/
 /*Fuzzy*/
-"tracing_permission_error_title_ios" = "COVID-19-Kontaktmitteilungen deaktiviert";
+"tracing_permission_error_title_ios" = "{TRACING_SETTING_TEXT} deaktiviert";
 
 /*Fehler-Text, wenn Tracing deaktiviert wurde im System, iOS*/
 /*Fuzzy*/
-"tracing_permission_error_text_ios" = "Aktivieren Sie COVID-19-Kontaktmitteilungen, damit das Tracing funktioniert.";
+"tracing_permission_error_text_ios" = "Aktivieren Sie {TRACING_SETTING_TEXT}, damit das Tracing funktioniert.";
 
 /*Error-Meldung, wenn der Benutzer während des Informieren-Flows bei GApple das Key-Sharing nicht erlaubt.*/
 "user_cancelled_key_sharing_error" = "Die Meldung konnte nicht gesendet werden. Bitte erlauben Sie das Teilen Ihrer zufälligen IDs mit der SwissCovid App.";
@@ -947,3 +947,13 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "COVID-19-Kontaktmitteilungen";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "COVID-19-Begegnungsaufzeichnungen";
+
+/*Text beim Bluetooth Control iOS 14*/
+/*Fuzzy*/
+"tracing_setting_text_ios_14_0" = "COVID-19-Begegnungsmeldungen";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -934,4 +934,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Exposure Notifications";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -926,3 +926,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/es.lproj/Localizable.strings
+++ b/Translations/es.lproj/Localizable.strings
@@ -921,3 +921,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/es.lproj/Localizable.strings
+++ b/Translations/es.lproj/Localizable.strings
@@ -929,4 +929,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Exposure Notifications";

--- a/Translations/fr.lproj/Localizable.strings
+++ b/Translations/fr.lproj/Localizable.strings
@@ -928,3 +928,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/fr.lproj/Localizable.strings
+++ b/Translations/fr.lproj/Localizable.strings
@@ -936,4 +936,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Notifications d’exposition";

--- a/Translations/hr.lproj/Localizable.strings
+++ b/Translations/hr.lproj/Localizable.strings
@@ -917,3 +917,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/hr.lproj/Localizable.strings
+++ b/Translations/hr.lproj/Localizable.strings
@@ -925,4 +925,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Exposure Notifications";

--- a/Translations/it.lproj/Localizable.strings
+++ b/Translations/it.lproj/Localizable.strings
@@ -936,4 +936,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Notifiche di esposizione";

--- a/Translations/it.lproj/Localizable.strings
+++ b/Translations/it.lproj/Localizable.strings
@@ -928,3 +928,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/pt.lproj/Localizable.strings
+++ b/Translations/pt.lproj/Localizable.strings
@@ -921,3 +921,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/pt.lproj/Localizable.strings
+++ b/Translations/pt.lproj/Localizable.strings
@@ -929,4 +929,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Notificações de exposição";

--- a/Translations/rm.lproj/Localizable.strings
+++ b/Translations/rm.lproj/Localizable.strings
@@ -917,3 +917,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/rm.lproj/Localizable.strings
+++ b/Translations/rm.lproj/Localizable.strings
@@ -925,4 +925,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Exposure Notifications";

--- a/Translations/sq.lproj/Localizable.strings
+++ b/Translations/sq.lproj/Localizable.strings
@@ -921,3 +921,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/sq.lproj/Localizable.strings
+++ b/Translations/sq.lproj/Localizable.strings
@@ -929,4 +929,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Exposure Notifications";

--- a/Translations/sr-Latn-RS.lproj/Localizable.strings
+++ b/Translations/sr-Latn-RS.lproj/Localizable.strings
@@ -917,3 +917,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/sr-Latn-RS.lproj/Localizable.strings
+++ b/Translations/sr-Latn-RS.lproj/Localizable.strings
@@ -925,4 +925,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Exposure Notifications";

--- a/Translations/ti.lproj/Localizable.strings
+++ b/Translations/ti.lproj/Localizable.strings
@@ -917,3 +917,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/ti.lproj/Localizable.strings
+++ b/Translations/ti.lproj/Localizable.strings
@@ -925,4 +925,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Exposure Notifications";

--- a/Translations/tr.lproj/Localizable.strings
+++ b/Translations/tr.lproj/Localizable.strings
@@ -917,3 +917,12 @@
 
 /*Telefonnummer der allgemeinen Infoline Coronavirus*/
 "infoline_coronavirus_number" = "+41 58 463 00 00";
+
+/*Text beim Bluetooth Control iOS 13.5*/
+"tracing_setting_text_ios_13_5" = "";
+
+/*Text beim Bluetooth Control iOS 13.6*/
+"tracing_setting_text_ios_13_6" = "";
+
+/*Text beim Bluetooth Control iOS 14*/
+"tracing_setting_text_ios_14_0" = "";

--- a/Translations/tr.lproj/Localizable.strings
+++ b/Translations/tr.lproj/Localizable.strings
@@ -925,4 +925,4 @@
 "tracing_setting_text_ios_13_6" = "";
 
 /*Text beim Bluetooth Control iOS 14*/
-"tracing_setting_text_ios_14_0" = "";
+"tracing_setting_text_ios_14_0" = "Maruz Kalma Bildirimleri";


### PR DESCRIPTION
This PR adds the ability to have iOS version-specific localisations. Since Apple changes the Settings localization of the Exposure Notification settings in 13.6 and 14.0 (beta)