### PR TITLE
improves exposed token handling

### DIFF
--- a/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
+++ b/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
@@ -82,9 +82,10 @@ class ReportingManager: ReportingManagerProtocol {
         DP3TTracing.iWasExposed(onset: date, authentication: .HTTPAuthorizationBearer(token: token), isFakeRequest: fake) { [weak self] result in
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
-                self.codeDictionary.removeValue(forKey: covidCode)
                 switch result {
                 case .success:
+                    self.codeDictionary.removeValue(forKey: covidCode)
+
                     if !fake {
                         // during infection, tracing is disabled
                         // after infection, it works again, but user must manually


### PR DESCRIPTION
Only discard code token if DP3TTracing.iWasExposed was successful. 
If the user declines the key-popup by accident we keep the token so he can retry with the same code.