### PR TITLE
fixes loading config on app update

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,2 +1,3 @@
 --disable wrapMultilineStatementBraces
-
+--disable initCoderUnavailable
+--disable redundantType

--- a/DP3TApp.xcodeproj/project.pbxproj
+++ b/DP3TApp.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 		F806D33D24F91C7800672DFC /* LocalPushProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F806D33B24F91C7800672DFC /* LocalPushProtocol.swift */; };
 		F806D33F24F91D5B00672DFC /* TracingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F806D33E24F91D5B00672DFC /* TracingManagerTests.swift */; };
 		F806D34124F91DB900672DFC /* MockIdentifierProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F806D34024F91DB900672DFC /* MockIdentifierProvider.swift */; };
+		F807812C25022091008986EE /* ConfigManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F807812B25022091008986EE /* ConfigManagerTests.swift */; };
 		F80E735A245AD7B400C934B8 /* URLSession+pinning.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80E7359245AD7B400C934B8 /* URLSession+pinning.swift */; };
 		F80E7371245AF51C00C934B8 /* www.pt1-a.bfs.admin.ch.der in Resources */ = {isa = PBXBuildFile; fileRef = F80E736E245AF38E00C934B8 /* www.pt1-a.bfs.admin.ch.der */; };
 		F80E7372245AF51C00C934B8 /* www.pt1-d.bfs.admin.ch.der in Resources */ = {isa = PBXBuildFile; fileRef = F80E736F245AF38E00C934B8 /* www.pt1-d.bfs.admin.ch.der */; };
@@ -559,6 +560,7 @@
 		F806D33B24F91C7800672DFC /* LocalPushProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPushProtocol.swift; sourceTree = "<group>"; };
 		F806D33E24F91D5B00672DFC /* TracingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingManagerTests.swift; sourceTree = "<group>"; };
 		F806D34024F91DB900672DFC /* MockIdentifierProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIdentifierProvider.swift; sourceTree = "<group>"; };
+		F807812B25022091008986EE /* ConfigManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigManagerTests.swift; sourceTree = "<group>"; };
 		F80E7359245AD7B400C934B8 /* URLSession+pinning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+pinning.swift"; sourceTree = "<group>"; };
 		F80E736D245AF38E00C934B8 /* www.pt1.bfs.admin.ch.der */ = {isa = PBXFileReference; lastKnownFileType = file; path = www.pt1.bfs.admin.ch.der; sourceTree = "<group>"; };
 		F80E736E245AF38E00C934B8 /* www.pt1-a.bfs.admin.ch.der */ = {isa = PBXFileReference; lastKnownFileType = file; path = "www.pt1-a.bfs.admin.ch.der"; sourceTree = "<group>"; };
@@ -1096,6 +1098,7 @@
 				F88585ED249272EE00018AEA /* TracingLocalPushTests.swift */,
 				F806D34024F91DB900672DFC /* MockIdentifierProvider.swift */,
 				F891129B24C96C4300DCB111 /* ConfigResponseBodyTests.swift */,
+				F807812B25022091008986EE /* ConfigManagerTests.swift */,
 				F806D33E24F91D5B00672DFC /* TracingManagerTests.swift */,
 				8E81CCB1241FCC7F006F2437 /* Info.plist */,
 				F84089EF24936D8700A66CD1 /* MockKeychain.swift */,
@@ -1892,6 +1895,7 @@
 				F891129C24C96C4300DCB111 /* ConfigResponseBodyTests.swift in Sources */,
 				F84089F024936D8700A66CD1 /* MockKeychain.swift in Sources */,
 				8E81CCB0241FCC7F006F2437 /* FakePublishManagerTests.swift in Sources */,
+				F807812C25022091008986EE /* ConfigManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DP3TApp/Logic/Config/ConfigManager.swift
+++ b/DP3TApp/Logic/Config/ConfigManager.swift
@@ -81,10 +81,8 @@ class ConfigManager: NSObject {
     }
 
     private func shouldLoadConfig(backgroundTask: Bool, url: String?) -> Bool {
-        // if the config url was changes (by OS version or app version changing) load config
-        if let lastUrl = Self.lastConfigUrl,
-            let url = url,
-            lastUrl != url {
+        // if the config url was changed (by OS version or app version changing) load config
+        if url != Self.lastConfigUrl {
             return true
         }
 

--- a/DP3TApp/Logic/Config/ConfigManager.swift
+++ b/DP3TApp/Logic/Config/ConfigManager.swift
@@ -80,16 +80,16 @@ class ConfigManager: NSObject {
         }
     }
 
-    private func shouldLoadConfig(backgroundTask: Bool, url: String?) -> Bool {
-        // if the config url was changed (by OS version or app version changing) load config
-        if url != Self.lastConfigUrl {
+    static func shouldLoadConfig(backgroundTask: Bool, url: String?, lastConfigUrl: String?, lastConfigLoad: Date?) -> Bool {
+        // if the config url was changed (by OS version or app version changing) load config in anycase
+        if url != lastConfigUrl {
             return true
         }
 
         if backgroundTask {
-            return Self.lastConfigLoad == nil || Date().timeIntervalSince(Self.lastConfigLoad!) > Self.configBackgroundValidityInterval
+            return lastConfigLoad == nil || Date().timeIntervalSince(lastConfigLoad!) > Self.configBackgroundValidityInterval
         } else {
-            return Self.lastConfigLoad == nil || Date().timeIntervalSince(Self.lastConfigLoad!) > Self.configForegroundValidityInterval
+            return lastConfigLoad == nil || Date().timeIntervalSince(lastConfigLoad!) > Self.configForegroundValidityInterval
         }
     }
 
@@ -112,7 +112,10 @@ class ConfigManager: NSObject {
     public func loadConfig(backgroundTask: Bool, completion: @escaping (ConfigResponseBody?) -> Void) {
         let request = Endpoint.config(appversion: ConfigManager.appVersion, osversion: ConfigManager.osVersion, buildnr: ConfigManager.buildNumber).request()
 
-        guard shouldLoadConfig(backgroundTask: backgroundTask, url: request.url?.absoluteString) else {
+        guard Self.shouldLoadConfig(backgroundTask: backgroundTask,
+                                    url: request.url?.absoluteString,
+                                    lastConfigUrl: Self.lastConfigUrl,
+                                    lastConfigLoad: Self.lastConfigLoad) else {
             Logger.log("Skipping config load request and returning from cache", appState: true)
             completion(Self.currentConfig)
             return

--- a/DP3TAppTests/ConfigManagerTests.swift
+++ b/DP3TAppTests/ConfigManagerTests.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+@testable import DP3TApp
+import XCTest
+
+class ConfigManagerTests: XCTestCase {
+    func testLoadingAfterTimeForeground() {
+        let lastLoad = Date(timeIntervalSinceNow: -ConfigManager.configForegroundValidityInterval)
+        XCTAssert(ConfigManager.shouldLoadConfig(backgroundTask: false, url: "url", lastConfigUrl: "url", lastConfigLoad: lastLoad))
+    }
+
+    func testDontLoadAfterTimeForeground() {
+        let lastLoad = Date(timeIntervalSinceNow: -ConfigManager.configForegroundValidityInterval + 1)
+        XCTAssertFalse(ConfigManager.shouldLoadConfig(backgroundTask: false, url: "url", lastConfigUrl: "url", lastConfigLoad: lastLoad))
+    }
+
+    func testLoadingAfterTimeBackground() {
+        let lastLoad = Date(timeIntervalSinceNow: -ConfigManager.configBackgroundValidityInterval)
+        XCTAssert(ConfigManager.shouldLoadConfig(backgroundTask: true, url: "url", lastConfigUrl: "url", lastConfigLoad: lastLoad))
+    }
+
+    func testDontLoadAfterTimeBackground() {
+        let lastLoad = Date(timeIntervalSinceNow: -ConfigManager.configBackgroundValidityInterval + 1)
+        XCTAssertFalse(ConfigManager.shouldLoadConfig(backgroundTask: true, url: "url", lastConfigUrl: "url", lastConfigLoad: lastLoad))
+    }
+
+    func testLoadConfigAfterUrlChange() {
+        XCTAssert(ConfigManager.shouldLoadConfig(backgroundTask: true, url: "newUrl", lastConfigUrl: "url", lastConfigLoad: .init()))
+    }
+
+    func testLoadConfigAfterUpdate() {
+        XCTAssert(ConfigManager.shouldLoadConfig(backgroundTask: true, url: "newUrl", lastConfigUrl: nil, lastConfigLoad: .init()))
+    }
+}


### PR DESCRIPTION
This fixes a bug in the config loading logic introduces with #250. Currently, if we do not have a previous configLoadUrl we wait for the next scheduled config load instead of doing it immediately. This PR fixes this logic and adds unit tests for the shouldLoadConfig method. The configLoadUrl is used to check if the operating system or the app was updated.