### PR TITLE
updates SDK (fixes issue of current day key export for iOS >= 13.7)

### DIFF
--- a/DP3TApp.xcodeproj/project.pbxproj
+++ b/DP3TApp.xcodeproj/project.pbxproj
@@ -3036,7 +3036,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DP-3T/dp3t-sdk-ios.git";
 			requirement = {
-				branch = "bugfix/ios-13-7-delayed-key-fix";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/DP3TApp.xcodeproj/project.pbxproj
+++ b/DP3TApp.xcodeproj/project.pbxproj
@@ -3036,7 +3036,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DP-3T/dp3t-sdk-ios.git";
 			requirement = {
-				branch = develop;
+				branch = "bugfix/ios-13-7-delayed-key-fix";
 				kind = branch;
 			};
 		};

--- a/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
         "package": "DP3TSDK",
         "repositoryURL": "https://github.com/DP-3T/dp3t-sdk-ios.git",
         "state": {
-          "branch": "develop",
-          "revision": "91792505e81a1b44e0393fc1a14f156ff7fca104",
+          "branch": "bugfix/ios-13-7-delayed-key-fix",
+          "revision": "04177f39cb9ac544f92c84ab1fa8aa927f811648",
           "version": null
         }
       },
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "cc10a0a3149579d36bc546d97064884cb818f324",
-          "version": "1.11.0"
+          "revision": "0279688c9fc5a40028e1b5bb0cb56534a45a6020",
+          "version": "1.12.0"
         }
       },
       {

--- a/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
         "package": "DP3TSDK",
         "repositoryURL": "https://github.com/DP-3T/dp3t-sdk-ios.git",
         "state": {
-          "branch": "bugfix/ios-13-7-delayed-key-fix",
-          "revision": "04177f39cb9ac544f92c84ab1fa8aa927f811648",
+          "branch": "develop",
+          "revision": "2845a8b6e060ac0e4fc730ad1fa3edd320be7537",
           "version": null
         }
       },

--- a/DP3TApp/Logic/Tracing/TracingManager.swift
+++ b/DP3TApp/Logic/Tracing/TracingManager.swift
@@ -144,6 +144,10 @@ class TracingManager: NSObject {
         #endif
     }
 
+    var isPositiveTestDeletable: Bool {
+        DP3TTracing.isInfectionStatusResettable
+    }
+
     func deletePositiveTest() {
         // reset infection status
         try? DP3TTracing.resetInfectionStatus()

--- a/DP3TApp/Logic/Tracing/UIState/Errors+Localized.swift
+++ b/DP3TApp/Logic/Tracing/UIState/Errors+Localized.swift
@@ -47,6 +47,8 @@ extension DP3TTracingError: LocalizedError, CodedError {
                 return "user_cancelled_key_sharing_error".ub_localized
             }
             return error.localizedDescription
+        case .infectionStatusNotResettable:
+            return nil
         }
     }
 
@@ -69,6 +71,8 @@ extension DP3TTracingError: LocalizedError, CodedError {
         case let .exposureNotificationError(error: error):
             let nsError = error as NSError
             return "IEN\(nsError.code)" // Should match code below
+        case .infectionStatusNotResettable:
+            return "ISNR"
         }
     }
 

--- a/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
@@ -90,7 +90,7 @@ class UIStateLogic {
                 tracing = .unexpectedError(code: error.errorCodeString)
             case .exposureNotificationError:
                 tracing = .tracingPermissionError(code: error.errorCodeString)
-            case .networkingError, .caseSynchronizationError, .userAlreadyMarkedAsInfected, .cancelled:
+            case .networkingError, .caseSynchronizationError, .userAlreadyMarkedAsInfected, .cancelled, .infectionStatusNotResettable:
                 // TODO: Something
                 break // networkingError should already be handled elsewhere, ignore caseSynchronizationError for now
             }

--- a/DP3TApp/Screens/Reports/NSReportsDetailPositiveTestedViewController.swift
+++ b/DP3TApp/Screens/Reports/NSReportsDetailPositiveTestedViewController.swift
@@ -89,5 +89,7 @@ class NSReportsDetailPositiveTestedViewController: NSTitleViewScrollViewControll
                 self?.present(alert, animated: true, completion: nil)
             }
         }
+
+        container.isHidden = !TracingManager.shared.isPositiveTestDeletable
     }
 }


### PR DESCRIPTION
Updates the DP3T SDK to the latest develop commit.
This includes a fix for iOS >= 13.7 current day key export https://github.com/DP-3T/dp3t-sdk-ios/pull/210/