### PR TITLE
fixes issue of current day key export for iOS >= 13.7 

### DIFF
--- a/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
+++ b/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
@@ -86,13 +86,6 @@ class ReportingManager: ReportingManagerProtocol {
                 case .success:
                     self.codeDictionary.removeValue(forKey: covidCode)
 
-                    if !fake {
-                        // during infection, tracing is disabled
-                        // after infection, it works again, but user must manually
-                        // enable if desired
-                        TracingManager.shared.isActivated = false
-                    }
-
                     TracingManager.shared.updateStatus(shouldSync: false) { error in
                         if let error = error {
                             completion(.failure(error: error))

--- a/DP3TApp/Logic/Tracing/TracingManager.swift
+++ b/DP3TApp/Logic/Tracing/TracingManager.swift
@@ -35,14 +35,8 @@ class TracingManager: NSObject {
         self.localPush = localPush
     }
 
-    @KeychainPersisted(key: "tracingIsActivated", defaultValue: true)
-    public var isActivated: Bool {
+    private(set) var isActivated: Bool = false {
         didSet {
-            if isActivated {
-                beginUpdatesAndTracing()
-            } else {
-                endTracing()
-            }
             UIStateManager.shared.changedTracingActivated()
         }
     }
@@ -107,7 +101,7 @@ class TracingManager: NSObject {
     }
 
     func beginUpdatesAndTracing() {
-        if UserStorage.shared.hasCompletedOnboarding, isActivated, ConfigManager.allowTracing {
+        if UserStorage.shared.hasCompletedOnboarding, ConfigManager.allowTracing {
             do {
                 try DP3TTracing.startTracing(completionHandler: { _ in
                     // When tracing is enabled trigger sync (for example after ENManager is initialized)
@@ -231,6 +225,8 @@ extension TracingManager: DP3TTracingDelegate {
         }
         // schedule local push if exposed
         localPush.scheduleExposureNotificationsIfNeeded(identifierProvider: state)
+
+        isActivated = state.trackingState == .active
     }
 }
 

--- a/DP3TApp/Screens/Homescreen/EncountersDetail/NSBluetoothSettingsControl.swift
+++ b/DP3TApp/Screens/Homescreen/EncountersDetail/NSBluetoothSettingsControl.swift
@@ -150,7 +150,11 @@ class NSBluetoothSettingsControl: UIView {
     @objc private func switchChanged() {
         // change tracing manager
         if TracingManager.shared.isActivated != switchControl.isOn {
-            TracingManager.shared.isActivated = switchControl.isOn
+            if switchControl.isOn {
+                TracingManager.shared.beginUpdatesAndTracing()
+            } else {
+                TracingManager.shared.endTracing()
+            }
         }
 
         UIAccessibility.post(notification: .layoutChanged, argument: switchControl)

--- a/DP3TApp/Screens/Homescreen/Homescreen/Reports/NSReportsModuleView.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/Reports/NSReportsModuleView.swift
@@ -62,7 +62,7 @@ class NSReportsModuleView: NSModuleBaseView {
     }))
 
     private let tracingDisabledView = NSTracingErrorView(model: NSTracingErrorView.NSTracingErrorViewModel(icon: UIImage(named: "ic-error")!, title: "meldungen_tracing_turned_off_title".ub_localized, text: "meldungen_tracing_not_active_warning".ub_localized, buttonTitle: "activate_tracing_button".ub_localized, action: { _ in
-        TracingManager.shared.isActivated = true
+        TracingManager.shared.beginUpdatesAndTracing()
     }))
 
     private let unexpectedErrorView = NSTracingErrorView(model: NSTracingErrorView.NSTracingErrorViewModel(icon: UIImage(named: "ic-error")!, title: "unexpected_error_title".ub_localized, text: "unexpected_error_title".ub_localized, buttonTitle: nil, action: nil))

--- a/DP3TApp/SharedUI/Views/NSTracingErrorView.swift
+++ b/DP3TApp/SharedUI/Views/NSTracingErrorView.swift
@@ -141,7 +141,7 @@ class NSTracingErrorView: UIView {
                                                text: "tracing_turned_off_text".ub_localized,
                                                buttonTitle: "activate_tracing_button".ub_localized,
                                                action: { _ in
-                                                   TracingManager.shared.isActivated = true
+                                                   TracingManager.shared.beginUpdatesAndTracing()
                                                })
             } else {
                 return NSTracingErrorViewModel(icon: UIImage(named: "ic-error")!,


### PR DESCRIPTION
- removes disabling of tracing after marking as infected as this has to be done by the SDK delayed in order to retrieve the current day key on iOS >= 13.7
- simplifies state handling. SDK is now the ground source of truth 