### PR TITLE
update error notification on status change

### DIFF
--- a/DP3TApp/Logic/Tracing/TracingManager.swift
+++ b/DP3TApp/Logic/Tracing/TracingManager.swift
@@ -231,6 +231,9 @@ extension TracingManager: DP3TTracingDelegate {
         }
         // schedule local push if exposed
         localPush.scheduleExposureNotificationsIfNeeded(identifierProvider: state)
+
+        // update tracing error states if needed
+        localPush.handleTracingState(state.trackingState)
     }
 }
 

--- a/DP3TAppTests/TracingManagerTests.swift
+++ b/DP3TAppTests/TracingManagerTests.swift
@@ -27,7 +27,11 @@ class MockLocalPush: LocalPushProtocol {
 
     func handleSync(result _: SyncResult) {}
 
-    func handleTracingState(_: TrackingState) {}
+    var handleTracingStateCalled = false
+
+    func handleTracingState(_: TrackingState) {
+        handleTracingStateCalled = true
+    }
 }
 
 class TracingManagerTests: XCTestCase {
@@ -55,6 +59,8 @@ class TracingManagerTests: XCTestCase {
         wait(for: [ex], timeout: 0.1)
 
         XCTAssert(mockLocalPush.scheduleExposureNotificationsIfNeededWasCalled)
+
+        XCTAssert(mockLocalPush.handleTracingStateCalled)
 
         try! DP3TTracing.reset()
     }


### PR DESCRIPTION
This might fix https://github.com/DP-3T/dp3t-app-ios-ch/issues/296 since the notifications have not been updated in the state handler. 
So it could happen that initially, the state was `.inactive(error: .bluetoothTurnedOff)` but the state would later change to the correct one.