### PR TITLE
Fix colors of bar chart related to high contrast mode

### DIFF
--- a/DP3TApp/Screens/Statistics/Chart/NSChartColumnView.swift
+++ b/DP3TApp/Screens/Statistics/Chart/NSChartColumnView.swift
@@ -25,10 +25,18 @@ class NSChartColumnView: UIView {
     }
 
 
-    var borderColor: UIColor = UIColor.setColorsForTheme(lightColor: .white , darkColor: .ns_darkModeBackground2) {
+    var borderColor: UIColor = .ns_background {
         didSet {
             layer.sublayers?.forEach {
                 $0.borderColor = borderColor.cgColor
+            }
+        }
+    }
+
+    var barBackgroundColor: UIColor = .ns_backgroundSecondary {
+        didSet {
+            layer.sublayers?.forEach {
+                $0.backgroundColor = barBackgroundColor.cgColor
             }
         }
     }
@@ -87,7 +95,7 @@ class NSChartColumnView: UIView {
 
     func newBar() -> CALayer {
         let layer = CALayer()
-        layer.backgroundColor = tintColor.cgColor
+        layer.backgroundColor = barBackgroundColor.cgColor
         layer.borderColor = borderColor.cgColor
         layer.borderWidth = configuration.barBorderWidth
         layer.anchorPoint = CGPoint(x: 0.5, y: 1.0)
@@ -98,7 +106,7 @@ class NSChartColumnView: UIView {
         if previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) ?? false {
             layer.sublayers?.forEach({ (layer) in
                 layer.borderColor = borderColor.cgColor
-                layer.backgroundColor = tintColor.cgColor
+                layer.backgroundColor = barBackgroundColor.cgColor
             })
         }
     }

--- a/DP3TApp/Screens/Statistics/Chart/NSStatisticsChartContentView.swift
+++ b/DP3TApp/Screens/Statistics/Chart/NSStatisticsChartContentView.swift
@@ -69,8 +69,8 @@ class NSStatisticsChartContentView: UIView {
         self.yAxisLines = .init(configuration: configuration)
         super.init(frame: .zero)
 
-        infectionBarView.tintColor = UIColor.ns_purpleBar
-        codeBarView.tintColor = .ns_blue
+        infectionBarView.barBackgroundColor = .ns_purpleBar
+        codeBarView.barBackgroundColor = .ns_blueBar
 
         infectionBarView.frame = frame
         codeBarView.frame = frame

--- a/DP3TApp/Screens/Statistics/NSStatisticsModuleView.swift
+++ b/DP3TApp/Screens/Statistics/NSStatisticsModuleView.swift
@@ -17,7 +17,7 @@ class NSStatisticsModuleView: UIView {
     private let header = NSStatsticsModuleHeader()
     let statisticsChartView = NSStatisticsChartView()
     private let legend = NSStatisticsModuleLegendView()
-    private let lastUpdatedLabel = NSLabel(.interRegular, textColor: .ns_backgroundDark, textAlignment: .right)
+    private let lastUpdatedLabel = NSLabel(.interRegular, textColor: .ns_gray, textAlignment: .right)
 
     private lazy var sections: [UIView] = [header,
                                            statisticsChartView,

--- a/DP3TApp/SharedUI/Style/UIColor+NS.swift
+++ b/DP3TApp/SharedUI/Style/UIColor+NS.swift
@@ -78,8 +78,11 @@ extension UIColor {
     public static var ns_tabbarNormalBlue = UIColor.setColorsForTheme(lightColor: UIColor(ub_hexString: "#4a4969")!, darkColor: UIColor(ub_hexString: "#cdcdd0")!)
     public static var ns_tabbarSelectedBlue = ns_blue
 
-    public static var ns_backgroundDark = UIColor(ub_hexString: "#cdcdd0")!.withHighContrastColor(color: .black)
+    static let grayColor = "#cdcdd0"
+    public static var ns_backgroundDark = UIColor(ub_hexString: grayColor)!.withHighContrastColor(color: .black)
 
+    public static var ns_gray = UIColor.setColorsForTheme(lightColor: UIColor(ub_hexString: grayColor)!.withHighContrastColor(color: .black),
+                                                          darkColor: UIColor(ub_hexString: grayColor)!.withHighContrastColor(color: .white))
     // MARK: - Splashscreen
 
     public static var ns_backgroundOnboardingSplashscreen = UIColor(ub_hexString: "#07a0e2")!

--- a/DP3TApp/SharedUI/Style/UIColor+NS.swift
+++ b/DP3TApp/SharedUI/Style/UIColor+NS.swift
@@ -24,7 +24,10 @@ extension UIColor {
         darkColor: UIColor.white
     )
 
-    public static var ns_blue = UIColor(ub_hexString: "#5094bf")!.withHighContrastColor(color: UIColor(ub_hexString: "#2769a3")!)
+    static let blueColor = "#5094bf"
+    public static var ns_blue = UIColor(ub_hexString: blueColor)!.withHighContrastColor(color: UIColor(ub_hexString: "#2769a3")!)
+    public static var ns_blueBar = UIColor(ub_hexString: blueColor)!
+
     public static var ns_lightBlue = UIColor(ub_hexString: "#00a7d4")!.withHighContrastColor(color: UIColor(ub_hexString: "#59738A")!)
     public static var ns_blueBackground: UIColor {
         return UIColor.setColorsForTheme(lightColor: UIColor(ub_hexString: "#eff5f9")!, darkColor: .ns_darkModeBackground2)
@@ -35,8 +38,10 @@ extension UIColor {
         darkColor: UIColor(ub_hexString: "#009e89")!
     )
 
-    public static var ns_purple = UIColor(ub_hexString: "#8d6a9f")!.withHighContrastColor(color: UIColor(ub_hexString: "#6e3f86")!)
-    public static var ns_purpleBar = UIColor.setColorsForTheme(lightColor: ns_purple.withAlphaComponent(0.3), darkColor: ns_purple.withAlphaComponent(0.5))
+    static let purpleColor = "#8d6a9f"
+    public static var ns_purple = UIColor(ub_hexString: purpleColor)!.withHighContrastColor(color: UIColor(ub_hexString: "#6e3f86")!)
+    public static var ns_purpleBar = UIColor.setColorsForTheme(lightColor: UIColor(ub_hexString: purpleColor)!.withAlphaComponent(0.3),
+                                                               darkColor: UIColor(ub_hexString: purpleColor)!.withAlphaComponent(0.5))
     public static var ns_greenBackground: UIColor {
         return UIColor.setColorsForTheme(lightColor: UIColor(ub_hexString: "#e5f8f6")!, darkColor: .ns_darkModeBackground2)
     }


### PR DESCRIPTION
Using tintColor results in weird behaviour when modal screen (about view
controller) is shown over bar chart. When the user leaves the app (taps
link or sends app to background) the bar chart is shown in high contrast
mode next time the user enters the app.

![High contrast](https://user-images.githubusercontent.com/35527968/93894067-9d517a00-fcee-11ea-976d-b4408b6a8f62.png)
