### PR TITLE
Use new .authorizationUnknown state to distinguish whether user denied permission or has not yet been prompted

### DIFF
--- a/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/DP-3T/dp3t-sdk-ios.git",
         "state": {
           "branch": "develop",
-          "revision": "aa987057a23ec598769d500aa9d766eaa471a95c",
+          "revision": "26464b940751657223038838c2f5debd87b792a1",
           "version": null
         }
       },

--- a/DP3TApp/Logic/Tracing/UIState/Errors+Localized.swift
+++ b/DP3TApp/Logic/Tracing/UIState/Errors+Localized.swift
@@ -41,6 +41,8 @@ extension DP3TTracingError: LocalizedError, CodedError {
             return "bluetooth_turned_off".ub_localized // custom UI, this should never be visible
         case .permissonError:
             return "bluetooth_permission_turned_off".ub_localized // custom UI, this should never be visible
+        case .authorizationUnknown:
+            return "authorization unknown" // custom UI, this should never be visible
         case let .exposureNotificationError(error: error):
             let nsError = error as NSError
             if nsError.domain == "ENErrorDomain", nsError.code == 4 {
@@ -66,6 +68,8 @@ extension DP3TTracingError: LocalizedError, CodedError {
             return "ICANCU"
         case .permissonError:
             return "IPERME"
+        case .authorizationUnknown:
+            return "IPERMU"
         case .userAlreadyMarkedAsInfected:
             return "IUAMAI"
         case let .exposureNotificationError(error: error):

--- a/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
@@ -86,6 +86,8 @@ class UIStateLogic {
                 tracing = .bluetoothTurnedOff
             case .permissonError:
                 tracing = .tracingPermissionError(code: nil)
+            case .authorizationUnknown:
+                tracing = .tracingAuthorizationUnknown
             case .databaseError:
                 tracing = .unexpectedError(code: error.errorCodeString)
             case .exposureNotificationError:

--- a/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
@@ -28,6 +28,7 @@ struct UIStateModel: Equatable {
         case bluetoothTurnedOff
         case bluetoothPermissionError
         case tracingPermissionError(code: String?)
+        case tracingAuthorizationUnknown
         case timeInconsistencyError
         case unexpectedError(code: String?)
         case tracingEnded

--- a/DP3TApp/Screens/Debugscreen/NSDebugScreenSDKStatusView.swift
+++ b/DP3TApp/Screens/Debugscreen/NSDebugScreenSDKStatusView.swift
@@ -108,7 +108,7 @@
                 switch state.homescreen.encounters {
                 case .tracingActive:
                     tracingLabel.text = "tracing_active_title".ub_localized
-                case .tracingDisabled, .bluetoothTurnedOff, .bluetoothPermissionError, .tracingEnded, .timeInconsistencyError, .unexpectedError, .tracingPermissionError:
+                case .tracingDisabled, .bluetoothTurnedOff, .bluetoothPermissionError, .tracingEnded, .timeInconsistencyError, .unexpectedError, .tracingPermissionError, .tracingAuthorizationUnknown:
                     tracingLabel.text = "bluetooth_setting_tracking_inactive".ub_localized
                 }
 

--- a/DP3TApp/Screens/Homescreen/EncountersDetail/NSBluetoothSettingsControl.swift
+++ b/DP3TApp/Screens/Homescreen/EncountersDetail/NSBluetoothSettingsControl.swift
@@ -182,7 +182,7 @@ class NSBluetoothSettingsControl: UIView {
             }, completion: nil)
 
         case .tracingDisabled, .tracingEnded: fallthrough
-        case .bluetoothTurnedOff, .bluetoothPermissionError, .timeInconsistencyError, .unexpectedError, .tracingPermissionError:
+        case .bluetoothTurnedOff, .bluetoothPermissionError, .timeInconsistencyError, .unexpectedError, .tracingPermissionError, .tracingAuthorizationUnknown:
             inactiveViewConstraint?.activate()
             activeViewConstraint?.deactivate()
 

--- a/DP3TApp/Screens/Homescreen/Homescreen/Header/NSHeaderErrorView.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/Header/NSHeaderErrorView.swift
@@ -94,7 +94,7 @@ class NSHeaderErrorView: UIView {
                 self.imageView.image = UIImage(named: "ic-header-bt-off")!
             case .bluetoothPermissionError:
                 self.imageView.image = UIImage(named: "ic-header-bt-disabled")!
-            case .tracingPermissionError:
+            case .tracingPermissionError, .tracingAuthorizationUnknown:
                 self.imageView.image = UIImage(named: "ic-tracing-error")!
             }
         }, completion: nil)

--- a/DP3TApp/Screens/Homescreen/Homescreen/Header/NSHeaderImageBackgroundView.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/Header/NSHeaderImageBackgroundView.swift
@@ -82,7 +82,7 @@ class NSHeaderImageBackgroundView: UIView {
             colorView.backgroundColor = UIColor.ns_blue.withHighContrastColor(color: UIColor(ub_hexString: "#63a0c7")!).withAlphaComponent(alpha)
         case .tracingDisabled:
             colorView.backgroundColor = UIColor.ns_darkBlueBackground.withHighContrastColor(color: UIColor(ub_hexString: "#4a4969")!).withAlphaComponent(alpha)
-        case .bluetoothPermissionError, .bluetoothTurnedOff, .timeInconsistencyError, .unexpectedError, .tracingPermissionError:
+        case .bluetoothPermissionError, .bluetoothTurnedOff, .timeInconsistencyError, .unexpectedError, .tracingPermissionError, .tracingAuthorizationUnknown:
             colorView.backgroundColor = UIColor.ns_red.withAlphaComponent(alpha)
         case .tracingEnded:
             colorView.backgroundColor = UIColor.ns_purple.withHighContrastColor(color: UIColor(ub_hexString: "#8d6a9f")!).withAlphaComponent(alpha)

--- a/DP3TApp/SharedUI/Views/NSTracingErrorView.swift
+++ b/DP3TApp/SharedUI/Views/NSTracingErrorView.swift
@@ -162,6 +162,14 @@ class NSTracingErrorView: UIView {
 
                                                UIApplication.shared.open(settingsUrl)
                                            })
+        case .tracingAuthorizationUnknown:
+            return NSTracingErrorViewModel(icon: UIImage(named: "ic-bluetooth-disabled")!,
+                                           title: "tracing_permission_error_title_ios".ub_localized.replaceSettingsString,
+                                           text: "tracing_permission_error_text_ios".ub_localized.replaceSettingsString,
+                                           buttonTitle: "onboarding_gaen_button_activate".ub_localized,
+                                           action: { _ in
+                                               TracingManager.shared.startTracing()
+                                           })
         case .bluetoothTurnedOff:
             return NSTracingErrorViewModel(icon: UIImage(named: "ic-bluetooth-off")!,
                                            title: "bluetooth_turned_off_title".ub_localized,


### PR DESCRIPTION
If user has not been prompted yet and taps on "Activate" we will startTracing() which in turn calls setExposureNotificationEnabled() which then results in the authorization prompt.

This is necessary after a user presses "Turn Off Exposure Notifications" in the iOS Settings.app, which revokes permissions and resets authorization to .unknown.