### PR TITLE
Fixes displaying of old chart labels when data is updated

### DIFF
--- a/DP3TApp/Screens/Statistics/Chart/NSChartYAxisLegend.swift
+++ b/DP3TApp/Screens/Statistics/Chart/NSChartYAxisLegend.swift
@@ -67,6 +67,12 @@ class NSChartYAxisLegend: UIView {
             y -= chartHeight * CGFloat(relativeStep) * CGFloat(i)
             label.frame = CGRect(x: 5, y: y, width: size.width, height: size.height)
         }
+
+        // remove unused labels
+        while labels.count > count {
+            _ = labels.popLast()?.removeFromSuperview()
+        }
+
         invalidateIntrinsicContentSize()
     }
 


### PR DESCRIPTION
This fixes an issue where not all chart legend labels have been used and the remaining ones keep getting displayed. This only happens if the app was opened shortly after being closed and there are new statistics data available that need a different amount of legend labels.