### PR TITLE
Fixes statistics X-achsis label layouting issue

### DIFF
--- a/DP3TApp/Screens/Statistics/Chart/NSStatisticsChartContentView.swift
+++ b/DP3TApp/Screens/Statistics/Chart/NSStatisticsChartContentView.swift
@@ -139,11 +139,6 @@ class NSStatisticsChartContentView: UIView {
         // Or if the first one is a monday
         if Calendar.current.component(.weekday, from: firstDate) == 2 {
             additionalPadding += NSPadding.large
-            infectionBarViewLeadingConstraint?.update(inset: NSPadding.large)
-            dateViewLeadingConstraint?.update(inset: NSPadding.large)
-        } else {
-            infectionBarViewLeadingConstraint?.update(inset: 0)
-            dateViewLeadingConstraint?.update(inset: 0)
         }
 
         return CGSize(width: CGFloat(data.data.count) * (configuration.barWidth + configuration.barBorderWidth) + configuration.barBorderWidth + additionalPadding,
@@ -161,6 +156,15 @@ class NSStatisticsChartContentView: UIView {
         codeBarView.values = data.data.map(\.codes)
         dateView.values = data.data.map(\.date)
         lineView.values = data.data.map(\.sevenDayAverage)
+
+        if let firstDate = data.data.first?.date,
+            Calendar.current.component(.weekday, from: firstDate) == 2 {
+            infectionBarViewLeadingConstraint?.update(inset: NSPadding.large)
+            dateViewLeadingConstraint?.update(inset: NSPadding.large)
+        } else {
+            infectionBarViewLeadingConstraint?.update(inset: 0)
+            dateViewLeadingConstraint?.update(inset: 0)
+        }
 
         yAxisLines.yTicks = data.yTicks
 

--- a/DP3TApp/Screens/Statistics/Chart/NSStatisticsChartContentView.swift
+++ b/DP3TApp/Screens/Statistics/Chart/NSStatisticsChartContentView.swift
@@ -119,8 +119,16 @@ class NSStatisticsChartContentView: UIView {
     }
 
     override var intrinsicContentSize: CGSize {
-        guard let data = data else { return CGSize(width: 0, height: configuration.chartHeight) }
-        return CGSize(width: CGFloat(data.data.count) * (configuration.barWidth + configuration.barBorderWidth) + configuration.barBorderWidth,
+        guard let data = data,
+            let lastDate = data.data.last?.date else { return CGSize(width: 0, height: configuration.chartHeight) }
+
+        // Add a small padding if the last day is a monday in order to not cut off the day label
+        var additionalPadding: CGFloat = 0.0
+        if Calendar.current.component(.weekday, from: lastDate) == 2 {
+            additionalPadding = NSPadding.medium
+        }
+
+        return CGSize(width: CGFloat(data.data.count) * (configuration.barWidth + configuration.barBorderWidth) + configuration.barBorderWidth + additionalPadding,
                       height: configuration.chartHeight)
     }
 


### PR DESCRIPTION
If the last data entry is from a Monday the label get cut off behind the Y-achsis:

![IMG_0009](https://user-images.githubusercontent.com/1466567/96914165-eee35500-14a4-11eb-8eb9-16440de8c7c6.jpg)

This PR adds a small padding if the last day is a Monday:

![IMG_0008](https://user-images.githubusercontent.com/1466567/96914211-fc004400-14a4-11eb-9cf1-8e2a6e7ec96e.PNG)
