### PR TITLE
fixes titleview scroll animation for large content

### DIFF
--- a/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
@@ -211,7 +211,13 @@ class UIStateLogic {
                 switch os {
                 case .infected:
                     infectionStatus = .infected
-                case .exposed:
+                case .exposed1:
+                    infectionStatus = .exposed(days: [])
+                case .exposed5:
+                    infectionStatus = .exposed(days: [])
+                case .exposed10:
+                    infectionStatus = .exposed(days: [])
+                case .exposed20:
                     infectionStatus = .exposed(days: [])
                 case .healthy:
                     infectionStatus = .healthy
@@ -229,10 +235,27 @@ class UIStateLogic {
         private func setDebugReports(_ newState: inout UIStateModel) {
             // in case the infection state is overwritten, we need to
             // add at least one report
-            if let os = manager.overwrittenInfectionState, os == .exposed {
-                newState.reportsDetail.reports = [UIStateModel.ReportsDetail.NSReportModel(identifier: Self.randIdentifier1, timestamp: Self.randDate1), UIStateModel.ReportsDetail.NSReportModel(identifier: Self.randIdentifier2, timestamp: Self.randDate2)].sorted(by: { (a, b) -> Bool in
-                    a.timestamp > b.timestamp
-                })
+            if let os = manager.overwrittenInfectionState {
+                var count = 1
+                switch os {
+                case .exposed1:
+                    count = 1
+                case .exposed5:
+                    count = 5
+                case .exposed10:
+                    count = 10
+                case .exposed20:
+                    count = 20
+                default:
+                    return
+                }
+
+                newState.reportsDetail.reports = []
+
+                for i in 0 ..< count {
+                    newState.reportsDetail.reports.append(UIStateModel.ReportsDetail.NSReportModel(identifier: UUID(), timestamp: Date(timeIntervalSinceNow: Double(i * 60 * 60 * 24 * -1))))
+                }
+
                 newState.shouldStartAtReportsDetail = true
                 newState.reportsDetail.showReportWithAnimation = true
 
@@ -248,7 +271,7 @@ class UIStateLogic {
             case .healthy:
                 newState.debug.infectionStatus = .healthy
             case .exposed:
-                newState.debug.infectionStatus = .exposed
+                newState.debug.infectionStatus = .exposed1
             case .infected:
                 newState.debug.infectionStatus = .infected
             }

--- a/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
@@ -101,10 +101,10 @@ struct UIStateModel: Equatable {
 
             enum DebugInfectionStatus: Equatable {
                 case healthy
-                case exposed1
-                case exposed5
-                case exposed10
-                case exposed20
+                case exposed1 // exposed with 1 contact
+                case exposed5 // exposed with 5 contact
+                case exposed10 // exposed with 10 contact
+                case exposed20 // exposed with 20 contact
                 case infected
             }
         }

--- a/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
@@ -101,7 +101,10 @@ struct UIStateModel: Equatable {
 
             enum DebugInfectionStatus: Equatable {
                 case healthy
-                case exposed
+                case exposed1
+                case exposed5
+                case exposed10
+                case exposed20
                 case infected
             }
         }

--- a/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
@@ -106,6 +106,12 @@ struct UIStateModel: Equatable {
                 case exposed10 // exposed with 10 contact
                 case exposed20 // exposed with 20 contact
                 case infected
+
+                static let exposedStates: [Self] = [.exposed1, .exposed5, .exposed10, .exposed20]
+
+                var isExposed: Bool {
+                    Self.exposedStates.contains(self)
+                }
             }
         }
     #endif

--- a/DP3TApp/Screens/Debugscreen/NSDebugScreenMockView.swift
+++ b/DP3TApp/Screens/Debugscreen/NSDebugScreenMockView.swift
@@ -16,7 +16,15 @@
     class NSDebugScreenMockView: NSSimpleModuleBaseView {
         private let stackView = UIStackView()
 
-        private let checkboxes = [NSCheckBoxView(text: "debug_state_setting_option_none".ub_localized), NSCheckBoxView(text: "debug_state_setting_option_ok".ub_localized), NSCheckBoxView(text: "debug_state_setting_option_exposed".ub_localized), NSCheckBoxView(text: "debug_state_setting_option_infected".ub_localized)]
+        private let checkboxes = [
+            NSCheckBoxView(text: "debug_state_setting_option_none".ub_localized),
+            NSCheckBoxView(text: "debug_state_setting_option_ok".ub_localized),
+            NSCheckBoxView(text: "debug_state_setting_option_exposed".ub_localized + " 1"),
+            NSCheckBoxView(text: "debug_state_setting_option_exposed".ub_localized + " 5"),
+            NSCheckBoxView(text: "debug_state_setting_option_exposed".ub_localized + " 10"),
+            NSCheckBoxView(text: "debug_state_setting_option_exposed".ub_localized + " 20"),
+            NSCheckBoxView(text: "debug_state_setting_option_infected".ub_localized),
+        ]
 
         // MARK: - Init
 
@@ -79,8 +87,14 @@
                     case 1:
                         stateManager.overwrittenInfectionState = .healthy
                     case 2:
-                        stateManager.overwrittenInfectionState = .exposed
+                        stateManager.overwrittenInfectionState = .exposed1
                     case 3:
+                        stateManager.overwrittenInfectionState = .exposed5
+                    case 4:
+                        stateManager.overwrittenInfectionState = .exposed10
+                    case 5:
+                        stateManager.overwrittenInfectionState = .exposed20
+                    case 6:
                         stateManager.overwrittenInfectionState = .infected
                     default:
                         stateManager.overwrittenInfectionState = nil
@@ -95,12 +109,18 @@
 
                 if let s = status {
                     checkboxes[1].isChecked = s == .healthy
-                    checkboxes[2].isChecked = s == .exposed
-                    checkboxes[3].isChecked = s == .infected
+                    checkboxes[2].isChecked = s == .exposed1
+                    checkboxes[3].isChecked = s == .exposed5
+                    checkboxes[4].isChecked = s == .exposed10
+                    checkboxes[5].isChecked = s == .exposed20
+                    checkboxes[6].isChecked = s == .infected
                 } else {
                     checkboxes[1].isChecked = false
                     checkboxes[2].isChecked = false
                     checkboxes[3].isChecked = false
+                    checkboxes[4].isChecked = false
+                    checkboxes[5].isChecked = false
+                    checkboxes[6].isChecked = false
                 }
             }
         #endif

--- a/DP3TApp/Screens/Debugscreen/NSDebugScreenSDKStatusView.swift
+++ b/DP3TApp/Screens/Debugscreen/NSDebugScreenSDKStatusView.swift
@@ -120,7 +120,8 @@
                 let isInfected = state.debug.infectionStatus == .infected
                 texts.append("\("debug_sdk_state_self_exposed".ub_localized)\(yesOrNo(isInfected))")
 
-                let isExposed = state.debug.infectionStatus == .exposed1 || state.debug.infectionStatus == .exposed5 || state.debug.infectionStatus == .exposed10 || state.debug.infectionStatus == .exposed20
+                let isExposed = state.debug.infectionStatus.isExposed
+
                 texts.append("\("debug_sdk_state_contact_exposed".ub_localized)\(yesOrNo(isExposed))")
 
                 commentsLabel.text = texts.joined(separator: "\n")

--- a/DP3TApp/Screens/Debugscreen/NSDebugScreenSDKStatusView.swift
+++ b/DP3TApp/Screens/Debugscreen/NSDebugScreenSDKStatusView.swift
@@ -120,7 +120,7 @@
                 let isInfected = state.debug.infectionStatus == .infected
                 texts.append("\("debug_sdk_state_self_exposed".ub_localized)\(yesOrNo(isInfected))")
 
-                let isExposed = state.debug.infectionStatus == .exposed
+                let isExposed = state.debug.infectionStatus == .exposed1 || state.debug.infectionStatus == .exposed5 || state.debug.infectionStatus == .exposed10 || state.debug.infectionStatus == .exposed20
                 texts.append("\("debug_sdk_state_contact_exposed".ub_localized)\(yesOrNo(isExposed))")
 
                 commentsLabel.text = texts.joined(separator: "\n")

--- a/DP3TApp/Screens/Reports/NSReportsDetailReportSingleTitleHeader.swift
+++ b/DP3TApp/Screens/Reports/NSReportsDetailReportSingleTitleHeader.swift
@@ -219,7 +219,7 @@ class NSReportsDetailReportSingleTitleHeader: NSTitleView {
         }
 
         continueButton.snp.makeConstraints { make in
-            make.top.equalTo(self.expandButton.snp.bottom).offset(NSPadding.large + NSPadding.medium)
+            make.top.equalTo(self.dateStackView.snp.bottom).offset(NSPadding.large + NSPadding.medium)
             make.centerX.equalToSuperview()
             make.left.right.lessThanOrEqualToSuperview().inset(NSPadding.large).priority(.low)
         }

--- a/DP3TApp/Screens/Reports/NSReportsDetailReportSingleTitleHeader.swift
+++ b/DP3TApp/Screens/Reports/NSReportsDetailReportSingleTitleHeader.swift
@@ -132,6 +132,8 @@ class NSReportsDetailReportSingleTitleHeader: NSTitleView {
         } else {
             expandButton.title = "meldung_detail_exposed_show_all_button".ub_localized
             subtitleLabel.text = "meldung_detail_exposed_subtitle_last_encounter".ub_localized
+
+            headerView?.stackScrollView.scrollView.setContentOffset(.zero, animated: false)
         }
     }
 

--- a/DP3TApp/Screens/Reports/NSReportsDetailReportViewController.swift
+++ b/DP3TApp/Screens/Reports/NSReportsDetailReportViewController.swift
@@ -304,8 +304,10 @@ extension NSReportsDetailReportViewController: NSHitTestDelegate {
             guard let titleView = titleView else {
                 return true
             }
+            // translate point into stackview space
+            let translatedPoint = point.applying(.init(translationX: 0, y: stackScrollView.scrollView.contentOffset.y))
             // and the hitTest Succeed we foreward the touch event
-            return titleView.hitTest(point, with: event) != nil
+            return titleView.hitTest(translatedPoint, with: event) != nil
         }
 
         return false

--- a/DP3TApp/Screens/Reports/NSTitleViewScrollViewController.swift
+++ b/DP3TApp/Screens/Reports/NSTitleViewScrollViewController.swift
@@ -139,19 +139,30 @@ class NSTitleViewScrollViewController: NSViewController {
 
 extension NSTitleViewScrollViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let sp: CGFloat
+        let titleHeight: CGFloat
         if useTitleViewHeight {
-            sp = titleView?.frame.height ?? startPositionScrollView
+            titleHeight = titleView?.frame.height ?? startPositionScrollView
         } else {
-            sp = startPositionScrollView
+            titleHeight = startPositionScrollView
         }
 
-        let v = (sp - scrollView.contentOffset.y) / sp
-        let p = max(0.0, min(1.0, v))
+        let coveringScreenPercentage = (titleHeight - scrollView.contentOffset.y) / scrollView.frame.height
 
-        titleView?.transform = CGAffineTransform(translationX: 0, y: min(0.0, -0.4 * scrollView.contentOffset.y))
+        let threshold = min(titleHeight / scrollView.frame.height, 0.5)
 
-        titleView?.alpha = pow(p, 0.8)
+        let maxYLinearOffset = max((titleHeight / scrollView.frame.height) * scrollView.frame.height - scrollView.frame.height / 2, 0)
+
+        var yOffset: CGFloat = min(scrollView.contentOffset.y, maxYLinearOffset)
+
+        if scrollView.contentOffset.y > maxYLinearOffset {
+            yOffset += max((scrollView.contentOffset.y - yOffset) * 0.4, 0)
+        }
+
+        titleView?.transform = CGAffineTransform(translationX: 0, y: -max(yOffset, 0))
+
+        let alpha = max(0.0, min(1.0, coveringScreenPercentage / threshold))
+
+        titleView?.alpha = pow(alpha, 0.8)
 
         titleView?.scrollViewDidScroll(scrollView)
     }


### PR DESCRIPTION
Problem was that on small phone the titleView was not visible completely since it was fading out on scroll. Now the fading starts when the end of the titleView is at 50% of scrollView height.

- also adds ability to simulate a different number of exposure days