### PR TITLE
Add end isolation popup

### DIFF
--- a/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
+++ b/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
@@ -49,6 +49,9 @@ class ReportingManager: ReportingManagerProtocol {
 
     let codeValidator = CodeValidator()
 
+    @UBOptionalUserDefault(key: "endIsolationQuestionDate")
+    var endIsolationQuestionDate: Date?
+
     // MARK: - API
 
     func report(covidCode: String, isFakeRequest fake: Bool = false, completion: @escaping (ReportingProblem?) -> Void) {
@@ -93,6 +96,7 @@ class ReportingManager: ReportingManagerProtocol {
                         if let error = error {
                             completion(.failure(error: error))
                         } else {
+                            self.endIsolationQuestionDate = Date().addingTimeInterval(60 * 60 * 24 * 14) // Ask if user wants to end isolation after 14 days
                             completion(nil)
                         }
                     }

--- a/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
+++ b/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
@@ -96,7 +96,9 @@ class ReportingManager: ReportingManagerProtocol {
                         if let error = error {
                             completion(.failure(error: error))
                         } else {
-                            self.endIsolationQuestionDate = Date().addingTimeInterval(60 * 60 * 24 * 14) // Ask if user wants to end isolation after 14 days
+                            if !fake {
+                                self.endIsolationQuestionDate = Date().addingTimeInterval(60 * 60 * 24 * 14) // Ask if user wants to end isolation after 14 days
+                            }
                             completion(nil)
                         }
                     }

--- a/DP3TApp/Logic/Tracing/TracingManager.swift
+++ b/DP3TApp/Logic/Tracing/TracingManager.swift
@@ -158,6 +158,10 @@ class TracingManager: NSObject {
 
     func deletePositiveTest() {
         guard #available(iOS 12.5, *) else { return }
+
+        // reset end isolation question date
+        ReportingManager.shared.endIsolationQuestionDate = nil
+
         // reset infection status
         DP3TTracing.resetInfectionStatus()
 

--- a/DP3TApp/Screens/Reports/NSReportsDetailPositiveTestedViewController.swift
+++ b/DP3TApp/Screens/Reports/NSReportsDetailPositiveTestedViewController.swift
@@ -79,7 +79,7 @@ class NSReportsDetailPositiveTestedViewController: NSTitleViewScrollViewControll
         deleteButton.touchUpCallback = { [weak self] in
 
             deleteButton.touchUpCallback = {
-                let alert = UIAlertController(title: nil, message: "delete_infection_dialog".ub_localized, preferredStyle: .actionSheet)
+                let alert = UIAlertController(title: nil, message: "delete_infection_dialog".ub_localized, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "delete_infection_dialog_finish_button".ub_localized, style: .destructive, handler: { _ in
                     TracingManager.shared.deletePositiveTest()
                 }))

--- a/Translations/bs.lproj/Localizable.strings
+++ b/Translations/bs.lproj/Localizable.strings
@@ -602,7 +602,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.\n\nRezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 4 sata?\nU tom slučaju, obratite se info liniji za virus korona.";
+"inform_detail_faq1_text" = "Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Šta se šalje?";
@@ -629,7 +629,7 @@
 "symptom_faq1_title" = "Koji su simptomi COVID-19?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Ovi simptomi se često javljaju:\n\n– temperatura, osećaj groznice\n– bolovi u grlu\n– kašalj (najčešće suv)\n– kratak dah\n– bolovi u mišićima\n– iznenadni gubitak čula mirisa i/ili ukusa";
+"symptom_faq1_text" = "Ovi simptomi se često javljaju:\n\n– temperatura, osećaj groznice\n– bolovi u grlu\n– kašalj (najčešće suv)\n– kratak dah\n– bolovi u grudima\n– iznenadni gubitak čula mirisa i/ili ukusa\n\nOsim toga, mogući su sledeći simptomi:\n\n– glavobolja\n– opšta slabost, malaksalost\n– bolovi u mišićima\n– kijavica\n– simptomi gastrointestinalnog trakta (mučnina, povraćanje, proliv, bolovi u stomaku)\n– osipi na koži";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Zbog čega je praćenje deaktivirano?";
@@ -1240,3 +1240,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Rezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 4 sata?\nU tom slučaju, obratite se info liniji za virus korona.";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -196,7 +196,7 @@
 "inform_detail_box_button" = "Covidcode eingeben";
 
 /*Informieren Detail Weisse Box Text*/
-"inform_detail_box_text" = "Mit der Eingabe des Covidcodes teilen Sie der App mit, dass Sie positiv auf das neue Coronavirus getestet wurden.";
+"inform_detail_box_text" = "Mit der Eingabe des Covidcodes teilen Sie der App mit, dass Sie positiv auf das Coronavirus getestet wurden.";
 
 /*Symptome Detail Subtitel*/
 "symptom_detail_subtitle" = "Was tun, wenn ich ...";
@@ -246,7 +246,7 @@
 "meldung_detail_positive_tested_title" = "Positiv getestet";
 
 /*Meldung Detail: Positiv Getestet Subtitel*/
-"meldung_detail_positive_tested_subtitle" = "Sie wurden positiv auf das neue Coronavirus getestet.";
+"meldung_detail_positive_tested_subtitle" = "Sie wurden positiv auf das Coronavirus getestet.";
 
 /*Meldung Detail Positiv Getestet Weisse Box Subtitel*/
 "meldung_detail_positive_test_box_subtitle" = "Was soll ich tun?";
@@ -273,7 +273,7 @@
 
 /*Meldung Detail Exposed Subtitel*/
 "meldung_detail_exposed_subtitle" = "Es besteht die Möglichkeit einer Ansteckung.";
-"meldung_homescreen_positiv_text" = "Sie wurden positiv auf das neue Coronavirus getestet.";
+"meldung_homescreen_positiv_text" = "Sie wurden positiv auf das Coronavirus getestet.";
 
 /*Debug Screen: Onboarding Reset Button*/
 "reset_onboarding" = "Onboarding zurücksetzen";
@@ -323,10 +323,10 @@
 "onboarding_prinzip_title" = "Dem Virus einen\nSchritt voraus";
 
 /*Onboarding Prinzip Text*/
-"onboarding_prinzip_text1" = "Mit der SwissCovid App können alle dazu beitragen, die Verbreitung des neuen Coronavirus einzudämmen.";
+"onboarding_prinzip_text1" = "Mit der SwissCovid App können alle dazu beitragen, die Verbreitung des Coronavirus einzudämmen.";
 
 /*Onboarding Prinzip Text*/
-"onboarding_prinzip_text2" = "Die App informiert Sie, wenn Sie potenziell dem neuen Coronavirus ausgesetzt waren.";
+"onboarding_prinzip_text2" = "Die App informiert Sie, wenn Sie potenziell dem Coronavirus ausgesetzt waren.";
 
 /*Onboarding Privacy: Titel oben*/
 "onboarding_privacy_heading" = "Privacy by Design";
@@ -359,7 +359,7 @@
 "onboarding_meldung_title" = "Meldung bei einer\nmöglichen Ansteckung";
 
 /*Onboarding Meldung: Text*/
-"onboarding_meldung_text1" = "Die App informiert Sie, wenn Sie potenziell dem neuen Coronavirus ausgesetzt waren.";
+"onboarding_meldung_text1" = "Die App informiert Sie, wenn Sie potenziell dem Coronavirus ausgesetzt waren.";
 
 /*Onboarding Meldung: Text*/
 "onboarding_meldung_text2" = "Mit dem richtigen Verhalten können Sie Infektionsketten unterbrechen und andere schützen.";
@@ -614,7 +614,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Positiv auf das neue Coronavirus getestete Personen erhalten einen Covidcode.\n\nDamit wird sichergestellt, dass nur bestätigte Fälle über die App gemeldet werden.\n\nSie wurden positiv getestet und haben nach 4h noch keinen Covidcode erhalten?\nDann kontaktieren Sie die Infoline Coronavirus:";
+"inform_detail_faq1_text" = "Positiv auf das Coronavirus getestete Personen erhalten einen Covidcode.\n\nDamit wird sichergestellt, dass nur bestätigte Fälle über die App gemeldet werden.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Was wird gesendet?";
@@ -641,7 +641,7 @@
 "symptom_faq1_title" = "Was sind COVID-19-Symptome?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Diese Symptome treten häufig auf:\n\n– Fieber, Fiebergefühl\n– Halsschmerzen\n– Husten (meist trocken)\n– Kurzatmigkeit\n– Muskelschmerzen\n– Plötzlicher Verlust des Geruchs- und/oder Geschmackssinns";
+"symptom_faq1_text" = "Diese Symptome treten häufig auf:\n\n– Fieber, Fiebergefühl\n– Halsschmerzen\n– Husten (meist trocken)\n– Kurzatmigkeit\n– Brustschmerzen\n– Plötzlicher Verlust des Geruchs- und oder Geschmackssinns\n\nZudem sind folgende Symptome möglich:\n\n– Kopfschmerzen\n– Allgemeine Schwäche, Unwohlsein\n– Muskelschmerzen\n– Schnupfen\n– Magen-Darm-Symptome (Übelkeit, Erbrechen, Durchfall, Bauchschmerzen)\n– Hautausschläge";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Warum ist das Tracing deaktiviert?";
@@ -1211,7 +1211,7 @@
 "test_location_popup_title" = "Wo kann ich einen Test machen?";
 
 /*Test standorte Popup Text*/
-"test_location_popup_text" = "Sie können sich bei verschiedenen Ärztinnen und Ärzten, Testzentren, Spitälern und Apotheken auf das neue Coronavirus testen lassen. Informationen zu den Testangeboten finden Sie auf den kantonalen Webseiten:";
+"test_location_popup_text" = "Sie können sich bei verschiedenen Ärztinnen und Ärzten, Testzentren, Spitälern und Apotheken auf das Coronavirus testen lassen. Informationen zu den Testangeboten finden Sie auf den kantonalen Webseiten:";
 
 /*Notification Channel name for Tracing Reactivation Reminders on Android Devices (Only visible in System Settings)*/
 "android_reminder_channel_name" = "Tracing-Aktivierungs Erinnerung";
@@ -1298,3 +1298,76 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+/*Fuzzy*/
+"hearing_impaired_info" = "Sind Sie gehörlos oder hörbehindert und können die Infoline Coronavirus nicht anrufen?\n\nDann senden Sie eine E-Mail an covid-support@medgate.ch";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "Covidcodes";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "eingegeben";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "Fallzahlen";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "aktuelle Entwicklung";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "Total";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "innert 0-2 Tagen";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "7-Tage-Schnitt";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "Δ Vorwoche";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "Details zu den Zahlen";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "Eingegebene Covidcodes";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "Fallzahlen";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "Anzahl der eingegebenen Covidcodes seit dem Start der SwissCovid App im Juni 2020. So viele Menschen haben durch die App ihre Kontakte über eine mögliche Ansteckung benachrichtigt.";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "Anteil der Covidcodes, die innerhalb der ersten beiden Tage nach Symptombeginn bereits eingegeben wurden.\n\nDie Zeit ist bei der Bekämpfung des Coronavirus ein entscheidender Faktor: je kürzer die Zeit zwischen Symptombeginn, Testresultat und der Covidcode-Eingabe, desto früher können benachrichtigte Kontakte zu Hause bleiben und andere schützen.";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "Zeigt den Durchschnitt der gemeldeten Neuinfektionen pro Tag über 7 Tage.";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "Zeigt die Differenz des 7-Tage-Schnitts im Vergleich zum Stand von vor einer Woche.";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "Aktuelle Entwicklung";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "Die Grafik zeigt die gemeldeten Neuinfektionen der letzten 28 Tage. Dies gibt einen Überblick über die aktuelle Entwicklung.";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Sie wurden positiv getestet und haben nach 4h noch keinen Covidcode erhalten?\nDann kontaktieren Sie die Infoline Coronavirus:";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "Noch keinen Covidcode?";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "Haben Sie Ihre Isolation beendet?";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "Das Tracing kann wieder aktiviert werden, sobald Sie die Isolation beendet haben.";
+
+/*Ja-Antwort*/
+"answer_yes" = "Ja";
+
+/*Nein-Antwort*/
+"answer_no" = "Nein";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -606,7 +606,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "People who have tested positive for the new coronavirus receive a Covidcode. \n\nThis ensures that only confirmed cases are notified via the app.\n\nYou have tested positive and after 4 hours have not yet received a Covidcode? \nIf this is the case, please contact the Coronavirus Infoline:";
+"inform_detail_faq1_text" = "People who have tested positive for the new coronavirus receive a Covidcode. \n\nThis ensures that only confirmed cases are notified via the app.";
 
 /*Not translated*/
 /*Inform Detail: FAQ Titel*/
@@ -634,7 +634,7 @@
 "symptom_faq1_title" = "What are the symptoms of COVID-19?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "These are the most common symptoms of COVID-19:\n\n– Fever, feverish feeling \n– Sore throat\n– Cough (mostly dry)\n– Shortness of breath\n– Body aches\n– Sudden loss of the sense of taste and/or smell";
+"symptom_faq1_text" = "These are the most common symptoms of COVID-19:\n\n– Fever, feverish feeling \n– Sore throat\n– Cough (mostly dry)\n– Shortness of breath\n– Body aches\n– Sudden loss of the sense of taste and/or smell\n\nOther symptoms may include:\n\n– Headache\n– General weakness, feeling unwell\n– Aching muscles\n– Head cold\n– Gastrointestinal symptoms (nausea, vomiting, diarrhoea, stomach ache)\n– Skin rash";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Why is tracing deactivated?";
@@ -1268,3 +1268,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "You have tested positive and after 4 hours have not yet received a Covidcode? \nIf this is the case, please contact the Coronavirus Infoline:";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/es.lproj/Localizable.strings
+++ b/Translations/es.lproj/Localizable.strings
@@ -602,7 +602,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Las personas que han dado positivo en el test del nuevo coronavirus reciben un código Covid. \n\nAsí se garantiza que la aplicación solo informe de los casos confirmados.\n\n¿Ha dado usted positivo en el test y no ha recibido el código Covid después de cuatro horas?\nEn este caso, póngase en contacto con la Infoline Coronavirus:";
+"inform_detail_faq1_text" = "Las personas que han dado positivo en el test del nuevo coronavirus reciben un código Covid. \n\nAsí se garantiza que la aplicación solo informe de los casos confirmados.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "¿Qué es lo que se envía?";
@@ -629,7 +629,7 @@
 "symptom_faq1_title" = "¿Cuáles son los síntomas de COVID-19?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Los síntomas siguientes aparecen con frecuencia:\n\n– fiebre, sensación febril\n– dolor de garganta\n– tos (casi siempre seca)\n– dificultad respiratoria\n– dolores musculares\n– pérdida repentina del sentido del gusto y/o del olfato";
+"symptom_faq1_text" = "Los síntomas siguientes aparecen con frecuencia:\n\n– fiebre, sensación febril\n– dolor de garganta\n– tos (casi siempre seca)\n– dificultad respiratoria\n– dolor en el pecho\n– pérdida repentina del sentido del gusto y/o del olfato    \nPueden aparecer también los síntomas siguientes:\n\n– dolor de cabeza\n– debilidad general, malestar\n– dolores musculares\n– catarro\n– síntomas gastrointestinales (nauseas, vómitos, diarrea, dolor de estómago)\n– erupciones cutáneas";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "¿Por qué está desactivado el rastreo?";
@@ -1240,3 +1240,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "¿Ha dado usted positivo en el test y no ha recibido el código Covid después de cuatro horas?\nEn este caso, póngase en contacto con la Infoline Coronavirus:";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/fr.lproj/Localizable.strings
+++ b/Translations/fr.lproj/Localizable.strings
@@ -606,7 +606,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Un code COVID est attribué aux personnes testées positives au nouveau coronavirus.\n\nCela permet d'assurer que seuls les cas confirmés sont signalés via l'application.\n\nVous n'avez toujours pas reçu de code COVID 4h après avoir été testé positif?\nVeuillez contacter l'infoline coronavirus:";
+"inform_detail_faq1_text" = "Un code COVID est attribué aux personnes testées positives au nouveau coronavirus.\n\nCela permet d'assurer que seuls les cas confirmés sont signalés via l'application.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Qu'est-ce qui est envoyé ?";
@@ -633,7 +633,7 @@
 "symptom_faq1_title" = "Quels sont les symptômes du COVID-19 ?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Ces symptômes sont fréquents :\n\n– Fièvre, sensation de fièvre\n– Mal de gorge\n– Toux (généralement sèche)\n– Difficultés respiratoires\n– Douleurs musculaires\n– Perte soudaine de l’odorat et/ou du goût";
+"symptom_faq1_text" = "Ces symptômes sont fréquents :\n\n– Fièvre, sensation de fièvre\n– Mal de gorge\n– Toux (généralement sèche)\n– Difficultés respiratoires\n– Douleurs dans la poitrine\n– Perte soudaine de l’odorat et/ou du goût\n\nLes symptômes suivants peuvent aussi apparaître :\n\n– Maux de tête\n– Faiblesse générale, sensation de malaise\n– Douleurs musculaires\n– Rhume\n– Symptômes gastro-intestinaux (nausées, vomissements, diarrhée, maux de ventre)\n– Éruptions cutanées";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Pourquoi le traçage est-il désactivé ?";
@@ -1273,3 +1273,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Vous n'avez toujours pas reçu de code COVID 4h après avoir été testé positif?\nVeuillez contacter l'infoline coronavirus:";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/hr.lproj/Localizable.strings
+++ b/Translations/hr.lproj/Localizable.strings
@@ -601,7 +601,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.\n\nRezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 4 sata?\nU tom slučaju, obratite se info liniji za virus korona.";
+"inform_detail_faq1_text" = "Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Šta se šalje?";
@@ -628,7 +628,7 @@
 "symptom_faq1_title" = "Koji su simptomi COVID-19?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Ovi simptomi se često javljaju:\n\n– temperatura, osećaj groznice\n– bolovi u grlu\n– kašalj (najčešće suv)\n– kratak dah\n– bolovi u mišićima\n– iznenadni gubitak čula mirisa i/ili ukusa";
+"symptom_faq1_text" = "Ovi simptomi se često javljaju:\n\n– temperatura, osećaj groznice\n– bolovi u grlu\n– kašalj (najčešće suv)\n– kratak dah\n– bolovi u grudima\n– iznenadni gubitak čula mirisa i/ili ukusa\n\nOsim toga, mogući su sledeći simptomi:\n\n– glavobolja\n– opšta slabost, malaksalost\n– bolovi u mišićima\n– kijavica\n– simptomi gastrointestinalnog trakta (mučnina, povraćanje, proliv, bolovi u stomaku)\n– osipi na koži";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Zbog čega je praćenje deaktivirano?";
@@ -1236,3 +1236,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Rezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 4 sata?\nU tom slučaju, obratite se info liniji za virus korona.";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/it.lproj/Localizable.strings
+++ b/Translations/it.lproj/Localizable.strings
@@ -606,7 +606,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Le persone che sono risultate positive al test del nuovo coronavirus ricevono un codice Covid.\n\nIn questo modo si garantisce che l'app segnali soltanto i casi confermati.\n\nSei risultato positivo al test e dopo quattro ore non hai ancora ricevuto un codice Covid? Allora contatta la Infoline Coronavirus";
+"inform_detail_faq1_text" = "Le persone che sono risultate positive al test del nuovo coronavirus ricevono un codice Covid.\n\nIn questo modo si garantisce che l'app segnali soltanto i casi confermati.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Che cosa viene inviato?";
@@ -633,7 +633,7 @@
 "symptom_faq1_title" = "Quali sono i sintomi della COVID-19?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Questi sono i sintomi più frequenti:\n\n– febbre, sensazione di febbre\n– mal di gola\n– tosse (perlopiù secca)\n– affanno\n– dolori muscolari\n– perdita improvvisa dell'olfatto e/o del gusto";
+"symptom_faq1_text" = "Questi sono i sintomi più frequenti:\n\n– febbre, sensazione di febbre\n– mal di gola\n– tosse (perlopiù secca)\n– affanno\n– dolori al petto\n– perdita improvvisa dell'olfatto e/o del gusto\n\nPossono inoltre comparire i seguenti sintomi:\n\n– mal di testa\n– malessere, debolezza generale\n– dolori muscolari\n– raffreddore\n– sintomi gastrointestinali (nausea, vomito, diarrea, mal di pancia)\n– eruzioni cutanee";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Perché il tracciamento è disattivato?";
@@ -1273,3 +1273,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Sei risultato positivo al test e dopo quattro ore non hai ancora ricevuto un codice Covid? Allora contatta la Infoline Coronavirus";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/pt.lproj/Localizable.strings
+++ b/Translations/pt.lproj/Localizable.strings
@@ -602,7 +602,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "As pessoas que testaram positivo para o novo coronavírus recebem um código COVID.\n\nIsto assegura que só os casos confirmados são assinalados na app.\n\nTestou positivo e ainda não recebeu nenhum código COVID ao fim de 4 h?\nNesse caso, contacte a linha informativa coronavírus:";
+"inform_detail_faq1_text" = "As pessoas que testaram positivo para o novo coronavírus recebem um código COVID.\n\nIsto assegura que só os casos confirmados são assinalados na app.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Que dados são enviados?";
@@ -629,7 +629,7 @@
 "symptom_faq1_title" = "Quais são os sintomas da COVID-19?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Estes sintomas são frequentes:\n\n– Febre, sensação de febre\n– Dores de garganta\n– Tosse (seca, na maioria dos casos)\n– Falta de ar\n– Dores musculares\n– Perda repentina do olfato e/ou do paladar";
+"symptom_faq1_text" = "Estes sintomas são frequentes:\n\n– Febre, sensação de febre\n– Dores de garganta\n– Tosse (seca, na maioria dos casos)\n– Falta de ar\n– Dores no peito\n– Perda repentina do olfato e/ou do paladar\n\nOutros sintomas podem ser:\n\n– Dores de cabeça\n– Fraqueza geral, indisposição\n– Dores musculares\n– Constipação\n– Sintomas gastrointestinais (náusea, vómito, diarréia, dores de estômago)\n– Erupções cutâneas";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Porque está o rastreamento desativado?";
@@ -1240,3 +1240,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Testou positivo e ainda não recebeu nenhum código COVID ao fim de 4 h?\nNesse caso, contacte a linha informativa coronavírus:";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/rm.lproj/Localizable.strings
+++ b/Translations/rm.lproj/Localizable.strings
@@ -601,7 +601,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Persunas ch’èn vegnidas testadas en moda positiva sin il nov coronavirus survegnan in code covid.\n      \nUschia vegni garantì che mo cas confermads vegnan avisads via l'app.\n\nVus essas vegnida testada resp. vegnì testà en moda positiva sin il coronavirus e n'avais suenter 4 uras anc retschavì nagin code covid? Alura contactai l'infoline coronavirus:";
+"inform_detail_faq1_text" = "Persunas ch’èn vegnidas testadas en moda positiva sin il nov coronavirus survegnan in code covid.\n      \nUschia vegni garantì che mo cas confermads vegnan avisads via l'app.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Tge vegn tramess?";
@@ -628,7 +628,7 @@
 "symptom_faq1_title" = "Tge èn sintoms da COVID-19?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Quests sintoms cumparan savens:\n\n– fevra, sentiment da fevra\n– mal la gula\n– tuss (per il solit tuss sitga)\n– respiraziun asmatica\n– mal ils musculs\n– perdita andetga da l'odurat e/u dal palat\n";
+"symptom_faq1_text" = "Quests sintoms cumparan savens:\n\n– fevra, sentiment da fevra\n– mal la gula\n– tuss (per il solit tuss sitga)\n– respiraziun asmatica\n– mal il pèz\n– perdita andetga da l'odurat e/u dal palat\n\nPussaivels èn er ils suandants sintoms:\n\n– mal il chau\n– deblezza generala, malesser\n– mal ils musculs\n– dafraid\n– sintoms dal tract digestiv (indispostadad, vomitar, diarrea, mal il venter)\n– eczems";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Pertge è il tracing deactivà?";
@@ -1236,3 +1236,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Vus essas vegnida testada resp. vegnì testà en moda positiva sin il coronavirus e n'avais suenter 4 uras anc retschavì nagin code covid? Alura contactai l'infoline coronavirus:";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/sq.lproj/Localizable.strings
+++ b/Translations/sq.lproj/Localizable.strings
@@ -602,7 +602,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Personat që kanë rezultuar pozitivë me koronavirusin e ri marrin një kod Covid.\n\nNë këtë mënyrë sigurohet që nga aplikacioni të sinjalizohen vetëm rastet e konfirmuara.\n\nKeni dalë pozitiv dhe pas 4 orësh nuk keni marrë ende asnjë kod Covid?\nAtëherë kontaktoni \"Infoline Coronavirus\":";
+"inform_detail_faq1_text" = "Personat që kanë rezultuar pozitivë me koronavirusin e ri marrin një kod Covid.\n\nNë këtë mënyrë sigurohet që nga aplikacioni të sinjalizohen vetëm rastet e konfirmuara.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Çfarë dërgohet?";
@@ -629,7 +629,7 @@
 "symptom_faq1_title" = "Çfarë simptomash ka COVID-19?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Simptomat më të shpeshta janë:\n\n– Temperaturë, ndjesi ethesh\n– Dhimbje fyti\n– Kollë (zakonisht e thatë)\n– Vështirësi në frymëmarrje\n– Dhimbje muskujsh\n– Humbje e papritur e shqisës së nuhatjes dhe/ose të shijuarit";
+"symptom_faq1_text" = "Simptomat më të shpeshta janë:\n\n– Temperaturë, ndjesi ethesh\n– Dhimbje fyti\n– Kollë (zakonisht e thatë)\n– Vështirësi në frymëmarrje\n– Dhimbje kraharori\n– Humbje e papritur e shqisës së nuhatjes dhe/ose të shijuarit\n\nJanë gjithashtu të mundshme simptomat e mëposhtme:\n\n– Dhimbje koke\n– Dobësi e përgjithshme, parehati\n– Dhimbje muskulore\n– Nuhat\nSimptoma gastrointestinale (të përziera, të vjella, diarre, dhimbje abdominale)\n– Skuqje e lëkurës";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Pse është çaktivizuar gjurmimi?";
@@ -1240,3 +1240,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Keni dalë pozitiv dhe pas 4 orësh nuk keni marrë ende asnjë kod Covid?\nAtëherë kontaktoni \"Infoline Coronavirus\":";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/sr-Latn-RS.lproj/Localizable.strings
+++ b/Translations/sr-Latn-RS.lproj/Localizable.strings
@@ -601,7 +601,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.\n\nRezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 4 sata?\nU tom slučaju, obratite se info liniji za virus korona.";
+"inform_detail_faq1_text" = "Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Šta se šalje?";
@@ -628,7 +628,7 @@
 "symptom_faq1_title" = "Koji su simptomi COVID-19?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Ovi simptomi se često javljaju:\n\n– temperatura, osećaj groznice\n– bolovi u grlu\n– kašalj (najčešće suv)\n– kratak dah\n– bolovi u mišićima\n– iznenadni gubitak čula mirisa i/ili ukusa";
+"symptom_faq1_text" = "Ovi simptomi se često javljaju:\n\n– temperatura, osećaj groznice\n– bolovi u grlu\n– kašalj (najčešće suv)\n– kratak dah\n– bolovi u grudima\n– iznenadni gubitak čula mirisa i/ili ukusa\n\nOsim toga, mogući su sledeći simptomi:\n\n– glavobolja\n– opšta slabost, malaksalost\n– bolovi u mišićima\n– kijavica\n– simptomi gastrointestinalnog trakta (mučnina, povraćanje, proliv, bolovi u stomaku)\n– osipi na koži";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "Zbog čega je praćenje deaktivirano?";
@@ -1236,3 +1236,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Rezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 4 sata?\nU tom slučaju, obratite se info liniji za virus korona.";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/ti.lproj/Localizable.strings
+++ b/Translations/ti.lproj/Localizable.strings
@@ -601,7 +601,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "ውጽኢት መርመርኦም ፖዚቲቭ ዝኾኑ ሰባት ኮቪድኮድ ይውሃቦም። ብኸምዚ መንገዲ እቶም ሕማም ዝተረጋገጸሎም ሰባት ጥራይ በቲ ኣፕ ከምዝምዝገቡ ይረጋገጽ። \n\nኣወንታ/ፖሲቲቭ ተመርሚርኩም ድሕሪ 4 ሰዓት ገና ናይ ኮቪድ ኮድ ኣይተወሃብኩም፧\nሽዑ እቲ ኢንፎላይን ኮሮናቫይረስ ርኸቡ ኢኹም፥";
+"inform_detail_faq1_text" = "ውጽኢት መርመርኦም ፖዚቲቭ ዝኾኑ ሰባት ኮቪድኮድ ይውሃቦም። ብኸምዚ መንገዲ እቶም ሕማም ዝተረጋገጸሎም ሰባት ጥራይ በቲ ኣፕ ከምዝምዝገቡ ይረጋገጽ። ";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "እንታይ እዩ ዝስደድ፧ ";
@@ -628,7 +628,7 @@
 "symptom_faq1_title" = "ምልክታት ኮቪድ-19 እንታይ እዩ፧";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "እዚኦም ምልክታት ብዙሕ ግዜ ይርኣዩ፦ \n– ረስኒ፣ ስምዒት ናይ ረስኒ\n– ቃንዛ ጎሮሮ\n– ሰዓል (መብዛሕትኡ ግዜ ደረቕ ሰዓል)\n– ሕጽረት እስትንፋስ\n– ቃንዛ ጨዋዳታት\n– ናይ ምሽታትን ናይ ምስትምቓርን ክእለት ብሃንደበት ምጥፋእ";
+"symptom_faq1_text" = "እዚኦም ምልክታት ብዙሕ ግዜ ይርኣዩ፦\n\n– ረስኒ፣ ስምዒት ናይ ረስኒ\n– ቃንዛ ጎሮሮ\n– ሰዓል (መብዛሕትኡ ግዜ ደረቕ ሰዓል)\n– ሕጽረት እስትንፋስ\n– ቃንዛ ኣፍ-ልቢ\n– ናይ ምሽታትን ናይ ምስትምቓርን ክእለት ብሃንደበት ምጥፋእ\n\n\nካብኡ ንየው ዝስዕቡ ምልክታት ክቕልቀሉ ይኽእሉ፥\n\n– ቃንዛ ርእሲ\n– ሓፈሻዊ ድኻም፣ ስግድግድ\n– ቃንዛ ጭዋዳታት\n– ሰዓል\n– ናይ ከብድን መዓንጣን ጸገማት (ስግድግድ፣ ምትፋእ፣ ውጽኣት፣ ቃንዛ ከብዲ)\n– ነድሪ ቆርበት";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "እቲ ምክትታል ስለምንታይ ተዓጽዩ፧";
@@ -1236,3 +1236,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "ኣወንታ/ፖሲቲቭ ተመርሚርኩም ድሕሪ 4 ሰዓት ገና ናይ ኮቪድ ኮድ ኣይተወሃብኩም፧\nሽዑ እቲ ኢንፎላይን ኮሮናቫይረስ ርኸቡ ኢኹም፥";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";

--- a/Translations/tr.lproj/Localizable.strings
+++ b/Translations/tr.lproj/Localizable.strings
@@ -601,7 +601,7 @@
 
 /*Inform Detail: FAQ Text*/
 /*Fuzzy*/
-"inform_detail_faq1_text" = "Korona virüsü testi pozitif olan kişilere Kovid kodu verilir.\n\nBu şekilde yalnızca onaylanmış vakaların uygulama üzerinden bildirilmesi garantilenir.\n\nTest sonucunuz pozitif çıktı ve 4 saat içerisinde henüz Covid kodunu almadınız mı?\nBu durumda, Corona Virüs Bilgi Hattı (Infoline) ile iletişime geçiniz:";
+"inform_detail_faq1_text" = "Korona virüsü testi pozitif olan kişilere Kovid kodu verilir.\n\nBu şekilde yalnızca onaylanmış vakaların uygulama üzerinden bildirilmesi garantilenir.";
 
 /*Inform Detail: FAQ Titel*/
 "inform_detail_faq2_title" = "Neler iletilir?";
@@ -628,7 +628,7 @@
 "symptom_faq1_title" = "KOVİD-19 semptomları nedir?";
 
 /*Symptome: FAQ Text*/
-"symptom_faq1_text" = "Bu semptomlar sıklıkla ortaya çıkmaktadır:\n\n– Ateş, ateşlenme\n– Boğaz ağrısı\n– Öksürme (genelde kuru)\n– Nefes darlığı\n– Kas ağrıları\n– Koku ve tad alma yetisinin aniden kaybolması";
+"symptom_faq1_text" = "Bu semptomlar sıklıkla ortaya çıkmaktadır:\n\n– Ateş, ateşlenme\n– Boğaz ağrısı\n– Öksürme (genelde kuru)\n– Nefes darlığı\n– Göğüs ağrıları\n– Koku ve tad alma yetisinin aniden kaybolması\n\nAyrıca bu semptomlar görülebilir:\n\n– Başağrıları\n– Genel halsizlik, rahatsızlık\n– Kas ağrıları\n– Nezle\n– Mide-bağırsak semptomları (bulantı, kusma, ishal, mide ağrıları)\n– Deri döküntüleri";
 
 /*Meldungen: Positiv getestet FAQ Titel*/
 "meldungen_positive_tested_faq1_title" = "İzleme neden devre dışı bırakıldı?";
@@ -1236,3 +1236,75 @@
 /*Fuzzy*/
 "testlocation_url_canton_zurich" = "https://www.zh.ch/de/gesundheit/coronavirus.html";
 "testlocation_url_country_liechtenstein" = "https://www.llv.li/inhalt/118724/amtsstellen/coronavirus";
+
+/*text for info box pop up for the hearing impaired*/
+"hearing_impaired_info" = "";
+
+/*Überschrift des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_title" = "";
+
+/*Untertitel des Covidcodes-Statistik-Moduls*/
+"stats_covidcodes_subtitle" = "";
+
+/*Überschrift des Fallzahlen-Statistik Moduls*/
+"stats_cases_title" = "";
+
+/*Untertitel des Fallzahlen-Statistik-Moduls*/
+"stats_cases_subtitle" = "";
+
+/*Label der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_label" = "";
+
+/*Label der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_label" = "";
+
+/*Label der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_label" = "";
+
+/*Label der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_label" = "";
+
+/*Überschrift des Info-Popups auf dem Statistik-Screen*/
+"stats_info_popup_title" = "";
+
+/*Untertitel des Infopopups zu Covidcodes-Statistiken*/
+"stats_info_popup_subtitle_covidcodes" = "";
+
+/*Untertitel des Infopopups zu Fallzahlen-Statistiken*/
+"stats_info_popup_subtitle_cases" = "";
+
+/*Beschreibung der "Total eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_total_description" = "";
+
+/*Beschreibung der "Innert 0-2 Tagen eingegebene Covidcodes" Statistik*/
+"stats_covidcodes_0to2days_description" = "";
+
+/*Beschreibung der "7-Tage-Schnitt Fallzahlen" Statistik*/
+"stats_cases_7day_average_description" = "";
+
+/*Beschreibung der "Änderung gegenüber Vorwoche Fallzahlen" Statistik*/
+"stats_cases_rel_prev_week_description" = "";
+
+/*Label der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_label" = "";
+
+/*Beschreibung der "Aktuelle Entwicklung" Statistik*/
+"stats_cases_current_description" = "";
+
+/*Inform Detail: Infobox Text*/
+"inform_detail_infobox1_text" = "Test sonucunuz pozitif çıktı ve 4 saat içerisinde henüz Covid kodunu almadınız mı?\nBu durumda, Corona Virüs Bilgi Hattı (Infoline) ile iletişime geçiniz:";
+
+/*Inform Detail: Infobox Title*/
+"inform_detail_infobox1_title" = "";
+
+/*Titel des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_title" = "";
+
+/*Text des Popups mit der Frage, ob der User die Isolation beendet hat*/
+"homescreen_isolation_ended_popup_text" = "";
+
+/*Ja-Antwort*/
+"answer_yes" = "";
+
+/*Nein-Antwort*/
+"answer_no" = "";


### PR DESCRIPTION
This pull request implements a popup that appears when the user opens the app after 14 or more days have passed since entering a valid covid code. The popup asks whether the user wants to end isolation and "reset" the app.

Additionally, the style of the already existing popup to manually end isolation in the isolation screen has been changed from `.actionSheet` to `.alert`.