### PR TITLE
tracing state handling bugfixes

### DIFF
--- a/DP3TApp/Logic/Tracing/TracingManager.swift
+++ b/DP3TApp/Logic/Tracing/TracingManager.swift
@@ -124,6 +124,8 @@ class TracingManager: NSObject {
             DP3TTracing.startTracing(completionHandler: { result in
                 switch result {
                 case .success:
+                    // reset stored error when starting tracing
+                    UIStateManager.shared.tracingStartError = nil
                     // When tracing is enabled trigger sync (for example after ENManager is initialized)
                     DatabaseSyncer.shared.forceSyncDatabase(completionHandler: nil)
                 case let .failure(error):

--- a/DP3TApp/Screens/Homescreen/EncountersDetail/NSEncountersDetailViewController.swift
+++ b/DP3TApp/Screens/Homescreen/EncountersDetail/NSEncountersDetailViewController.swift
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import DP3TSDK
 import UIKit
 
 class NSEncountersDetailViewController: NSTitleViewScrollViewController {
@@ -36,7 +37,15 @@ class NSEncountersDetailViewController: NSTitleViewScrollViewController {
 
         bluetoothControl.switchCallback = { [weak self] state, confirmCallback in
             guard let self = self else { return }
-            // onyl show popup when switching tracing off
+            // if trackingState is permissonError show tutorial view
+            if case TrackingState.inactive(error: .permissonError) = UIStateManager.shared.trackingState,
+               #available(iOS 13.7, *) {
+                confirmCallback(!state)
+                guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+                NSSettingsTutorialViewController.present(from: appDelegate.tabBarController)
+                return
+            }
+            // only show popup when switching tracing off
             guard !state else {
                 TracingLocalPush.shared.resetReminderNotification()
                 confirmCallback(state)


### PR DESCRIPTION
- fixes issue where stored tracing start error was not cleared after successfully starting tracing
- show tutorial view when trying to switch on tracing while we are in a permission error state