### PR TITLE
Also present end isolation popup if user comes from background

### DIFF
--- a/DP3TApp/Screens/Homescreen/Homescreen/NSHomescreenViewController.swift
+++ b/DP3TApp/Screens/Homescreen/Homescreen/NSHomescreenViewController.swift
@@ -29,8 +29,6 @@ class NSHomescreenViewController: NSTitleViewScrollViewController {
 
     private let appTitleView = NSAppTitleView()
 
-    private var isFirstAppearance: Bool = true
-
     // MARK: - View
 
     override init() {
@@ -123,11 +121,6 @@ class NSHomescreenViewController: NSTitleViewScrollViewController {
 
         finishTransition?()
         finishTransition = nil
-
-        if isFirstAppearance {
-            isFirstAppearance = false
-            showEndIsolationPopupIfNecessary()
-        }
     }
 
     private var finishTransition: (() -> Void)?
@@ -362,25 +355,4 @@ class NSHomescreenViewController: NSTitleViewScrollViewController {
             }
         }
     #endif
-
-    // MARK: - End isolation popup
-
-    private func showEndIsolationPopupIfNecessary() {
-        // If the state is not infected, never show the end isolation popup
-        guard lastState.homescreen.reports.report == .infected else {
-            return
-        }
-
-        if let questionDate = ReportingManager.shared.endIsolationQuestionDate, questionDate < Date() {
-            let alert = UIAlertController(title: "homescreen_isolation_ended_popup_title".ub_localized, message: "homescreen_isolation_ended_popup_text".ub_localized, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "answer_yes".ub_localized, style: .default, handler: { _ in
-                TracingManager.shared.deletePositiveTest()
-            }))
-            alert.addAction(UIAlertAction(title: "answer_no".ub_localized, style: .cancel, handler: { _ in
-                ReportingManager.shared.endIsolationQuestionDate = Date().addingTimeInterval(60 * 60 * 24) // Ask again in 1 day
-            }))
-
-            present(alert, animated: true, completion: nil)
-        }
-    }
 }


### PR DESCRIPTION
This PR changes the logic of the end isolation popup so it is presented even if the user opens the app from the background.