### PR TITLE
Display oldest key date instead of onset date

### DIFF
--- a/DP3TApp.xcodeproj/project.pbxproj
+++ b/DP3TApp.xcodeproj/project.pbxproj
@@ -3449,8 +3449,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DP-3T/dp3t-sdk-ios.git";
 			requirement = {
-				branch = "feature/expose-oldest-keydate";
-				kind = branch;
+				kind = revision;
+				revision = 73bd75702b724310b091b24fc2603a74d25ed9a8;
 			};
 		};
 		F870A5B52492C6D500C34FFA /* XCRemoteSwiftPackageReference "SQLite" */ = {

--- a/DP3TApp.xcodeproj/project.pbxproj
+++ b/DP3TApp.xcodeproj/project.pbxproj
@@ -229,15 +229,15 @@
 		6E7C0D43242E44D80017C4F9 /* NSWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7C0D42242E44D80017C4F9 /* NSWebViewController.swift */; };
 		6E7C0D45242E4AA90017C4F9 /* NSLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7C0D44242E4AA90017C4F9 /* NSLoadingView.swift */; };
 		6E7C0D47242E58600017C4F9 /* NSAboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7C0D46242E58600017C4F9 /* NSAboutViewController.swift */; };
+		6E88973C261F01BA00508334 /* NSReportsLeitfadenInfoPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E88973B261F01BA00508334 /* NSReportsLeitfadenInfoPopupViewController.swift */; };
 		6E889756261F228200508334 /* NSOnboardingBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E889755261F228200508334 /* NSOnboardingBaseViewController.swift */; };
 		6E88975F261F25A700508334 /* NSOnboardingBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E889755261F228200508334 /* NSOnboardingBaseViewController.swift */; };
 		6E889765261F27D400508334 /* NSUpdateBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E889764261F27D400508334 /* NSUpdateBoardingViewController.swift */; };
 		6E88976B261F288300508334 /* NSUpdateBoardingGermanyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E88976A261F288300508334 /* NSUpdateBoardingGermanyViewController.swift */; };
-		6E9D79182625BF6C005C7B7F /* NSUpdateBoardingGermanyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E88976A261F288300508334 /* NSUpdateBoardingGermanyViewController.swift */; };
-		6E9D791D2625BF77005C7B7F /* NSUpdateBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E889764261F27D400508334 /* NSUpdateBoardingViewController.swift */; };
-		6E88973C261F01BA00508334 /* NSReportsLeitfadenInfoPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E88973B261F01BA00508334 /* NSReportsLeitfadenInfoPopupViewController.swift */; };
 		6E8FC0FA24518BF2002AB1E5 /* UIScrollView+UBKeyboardObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E8FC0F724518BF2002AB1E5 /* UIScrollView+UBKeyboardObserver.m */; };
 		6E8FC0FB24518BF2002AB1E5 /* UBKeyboardObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E8FC0F924518BF2002AB1E5 /* UBKeyboardObserver.m */; };
+		6E9D79182625BF6C005C7B7F /* NSUpdateBoardingGermanyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E88976A261F288300508334 /* NSUpdateBoardingGermanyViewController.swift */; };
+		6E9D791D2625BF77005C7B7F /* NSUpdateBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E889764261F27D400508334 /* NSUpdateBoardingViewController.swift */; };
 		6E9D79262625C02D005C7B7F /* NSReportsLeitfadenInfoPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E88973B261F01BA00508334 /* NSReportsLeitfadenInfoPopupViewController.swift */; };
 		6EA49E2924443E69009EFCAB /* NSSimpleTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA49E2824443E69009EFCAB /* NSSimpleTextButton.swift */; };
 		6EC47BD42451C3C2000D7686 /* NSReportsDetailReportSingleTitleHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC47BD32451C3C2000D7686 /* NSReportsDetailReportSingleTitleHeader.swift */; };
@@ -574,10 +574,10 @@
 		6E7C0D42242E44D80017C4F9 /* NSWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSWebViewController.swift; sourceTree = "<group>"; };
 		6E7C0D44242E4AA90017C4F9 /* NSLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLoadingView.swift; sourceTree = "<group>"; };
 		6E7C0D46242E58600017C4F9 /* NSAboutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAboutViewController.swift; sourceTree = "<group>"; };
+		6E88973B261F01BA00508334 /* NSReportsLeitfadenInfoPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSReportsLeitfadenInfoPopupViewController.swift; sourceTree = "<group>"; };
 		6E889755261F228200508334 /* NSOnboardingBaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSOnboardingBaseViewController.swift; sourceTree = "<group>"; };
 		6E889764261F27D400508334 /* NSUpdateBoardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSUpdateBoardingViewController.swift; sourceTree = "<group>"; };
 		6E88976A261F288300508334 /* NSUpdateBoardingGermanyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSUpdateBoardingGermanyViewController.swift; sourceTree = "<group>"; };
-		6E88973B261F01BA00508334 /* NSReportsLeitfadenInfoPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSReportsLeitfadenInfoPopupViewController.swift; sourceTree = "<group>"; };
 		6E8FC0F524518BF1002AB1E5 /* DP3TApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DP3TApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		6E8FC0F624518BF2002AB1E5 /* UIScrollView+UBKeyboardObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIScrollView+UBKeyboardObserver.h"; sourceTree = "<group>"; };
 		6E8FC0F724518BF2002AB1E5 /* UIScrollView+UBKeyboardObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIScrollView+UBKeyboardObserver.m"; sourceTree = "<group>"; };
@@ -3449,8 +3449,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DP-3T/dp3t-sdk-ios.git";
 			requirement = {
-				kind = revision;
-				revision = a9b876ef6ba115130cd9df3b8e249bcd6faed4b3;
+				branch = "feature/expose-oldest-keydate";
+				kind = branch;
 			};
 		};
 		F870A5B52492C6D500C34FFA /* XCRemoteSwiftPackageReference "SQLite" */ = {

--- a/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
         "package": "DP3TSDK",
         "repositoryURL": "https://github.com/DP-3T/dp3t-sdk-ios.git",
         "state": {
-          "branch": "feature/expose-oldest-keydate",
-          "revision": "2893d158c47b82dbaf3d4f18da601337471ff419",
+          "branch": null,
+          "revision": "73bd75702b724310b091b24fc2603a74d25ed9a8",
           "version": null
         }
       },

--- a/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
         "package": "DP3TSDK",
         "repositoryURL": "https://github.com/DP-3T/dp3t-sdk-ios.git",
         "state": {
-          "branch": null,
-          "revision": "a9b876ef6ba115130cd9df3b8e249bcd6faed4b3",
+          "branch": "feature/expose-oldest-keydate",
+          "revision": "2893d158c47b82dbaf3d4f18da601337471ff419",
           "version": null
         }
       },

--- a/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
+++ b/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
@@ -102,9 +102,9 @@ class ReportingManager: ReportingManagerProtocol {
                             if !fake {
                                 self.endIsolationQuestionDate = Date().addingTimeInterval(60 * 60 * 24 * 14) // Ask if user wants to end isolation after 14 days
 
-                                let oldestSharedKeyDate = wrapper.oldestKeyDate ?? Date()
+                                let oldestKeyDate = wrapper.oldestKeyDate ?? Date()
                                 // keys older than 10 days are never persisted on the server
-                                self.oldestSharedKeyDate = max(oldestSharedKeyDate, Date(timeIntervalSinceNow: -60 * 60 * 24 * 10))
+                                self.oldestSharedKeyDate = max(oldestKeyDate, Date(timeIntervalSinceNow: -60 * 60 * 24 * 10))
                             }
                             completion(nil)
                         }

--- a/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
+++ b/DP3TApp/Logic/Tracing/Reporting/ReportingManager.swift
@@ -49,8 +49,8 @@ class ReportingManager: ReportingManagerProtocol {
 
     let codeValidator = CodeValidator()
 
-    @KeychainPersisted(key: "onsetDate", defaultValue: nil)
-    var onsetDate: Date?
+    @KeychainPersisted(key: "oldestSharedKeyDate", defaultValue: nil)
+    var oldestSharedKeyDate: Date?
 
     @UBOptionalUserDefault(key: "endIsolationQuestionDate")
     var endIsolationQuestionDate: Date?
@@ -92,7 +92,7 @@ class ReportingManager: ReportingManagerProtocol {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 switch result {
-                case .success:
+                case let .success(wrapper):
                     self.codeDictionary.removeValue(forKey: covidCode)
 
                     TracingManager.shared.updateStatus(shouldSync: false) { error in
@@ -102,7 +102,9 @@ class ReportingManager: ReportingManagerProtocol {
                             if !fake {
                                 self.endIsolationQuestionDate = Date().addingTimeInterval(60 * 60 * 24 * 14) // Ask if user wants to end isolation after 14 days
 
-                                self.onsetDate = date
+                                let oldestSharedKeyDate = wrapper.oldestKeyDate ?? Date()
+                                // keys older than 10 days are never persisted on the server
+                                self.oldestSharedKeyDate = max(oldestSharedKeyDate, Date(timeIntervalSinceNow: -60 * 60 * 24 * 10))
                             }
                             completion(nil)
                         }

--- a/DP3TApp/Logic/Tracing/TracingManager.swift
+++ b/DP3TApp/Logic/Tracing/TracingManager.swift
@@ -166,7 +166,7 @@ class TracingManager: NSObject {
 
         // reset end isolation question date and onset date
         ReportingManager.shared.endIsolationQuestionDate = nil
-        ReportingManager.shared.onsetDate = nil
+        ReportingManager.shared.oldestSharedKeyDate = nil
 
         // reset infection status
         DP3TTracing.resetInfectionStatus()

--- a/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
@@ -47,10 +47,10 @@ class UIStateLogic {
         //
 
         var infectionStatus = tracingState.infectionStatus
-        var onsetDate = ReportingManager.shared.onsetDate
+        var oldestSharedKeyDate = ReportingManager.shared.oldestSharedKeyDate
         #if ENABLE_STATUS_OVERRIDE
             setDebugOverwrite(&infectionStatus, &newState)
-            setDebugOnsetDate(&onsetDate)
+            setDebugSharedKeyDate(&oldestSharedKeyDate)
         #endif
 
         switch infectionStatus {
@@ -58,7 +58,7 @@ class UIStateLogic {
             break
 
         case .infected:
-            setInfectedState(&newState, onsetDate: onsetDate)
+            setInfectedState(&newState, oldestSharedKeyDate: oldestSharedKeyDate)
 
         case let .exposed(days):
             setExposedState(&newState, days: days)
@@ -68,7 +68,7 @@ class UIStateLogic {
         // Set debug helpers
         #if ENABLE_STATUS_OVERRIDE
             setDebugReports(&newState)
-            setDebugDisplayValues(&newState, tracingState: tracingState, onsetDate: onsetDate)
+            setDebugDisplayValues(&newState, tracingState: tracingState, oldestSharedKeyDate: oldestSharedKeyDate)
         #endif
 
         #if ENABLE_LOGGING && ENABLE_STATUS_OVERRIDE
@@ -176,9 +176,9 @@ class UIStateLogic {
 
     // MARK: - Set global state to infected or exposed
 
-    private func setInfectedState(_ newState: inout UIStateModel, onsetDate: Date?) {
-        newState.homescreen.reports.report = .infected(onsetDate: onsetDate)
-        newState.reportsDetail.report = .infected(onsetDate: onsetDate)
+    private func setInfectedState(_ newState: inout UIStateModel, oldestSharedKeyDate: Date?) {
+        newState.homescreen.reports.report = .infected(oldestSharedKeyDate: oldestSharedKeyDate)
+        newState.reportsDetail.report = .infected(oldestSharedKeyDate: oldestSharedKeyDate)
         newState.homescreen.header = .tracingEnded
         newState.homescreen.encounters = .tracingEnded
     }
@@ -267,7 +267,7 @@ class UIStateLogic {
             }
         }
 
-        private func setDebugDisplayValues(_ newState: inout UIStateModel, tracingState: TracingState, onsetDate: Date?) {
+        private func setDebugDisplayValues(_ newState: inout UIStateModel, tracingState: TracingState, oldestSharedKeyDate: Date?) {
             newState.debug.lastSync = tracingState.lastSync
 
             // add real tracing state of sdk and overwritten state
@@ -277,15 +277,15 @@ class UIStateLogic {
             case .exposed:
                 newState.debug.infectionStatus = .exposed1
             case .infected:
-                newState.debug.infectionStatus = .infected(onsetDate: onsetDate)
+                newState.debug.infectionStatus = .infected(oldestSharedKeyDate: oldestSharedKeyDate)
             }
         }
 
-        private func setDebugOnsetDate(_ newDate: inout Date?) {
+        private func setDebugSharedKeyDate(_ newDate: inout Date?) {
             if
                 let os = manager.overwrittenInfectionState,
-                case let .infected(onsetDate) = os {
-                newDate = onsetDate
+                case let .infected(oldestSharedKeyDate) = os {
+                newDate = oldestSharedKeyDate
             }
         }
     #endif

--- a/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateModel.swift
@@ -37,7 +37,7 @@ struct UIStateModel: Equatable {
     enum ReportState: Equatable {
         case noReport
         case exposed
-        case infected(onsetDate: Date?)
+        case infected(oldestSharedKeyDate: Date?)
 
         var isInfected: Bool {
             if case .infected = self {
@@ -114,7 +114,7 @@ struct UIStateModel: Equatable {
                 case exposed5 // exposed with 5 contact
                 case exposed10 // exposed with 10 contact
                 case exposed20 // exposed with 20 contact
-                case infected(onsetDate: Date?)
+                case infected(oldestSharedKeyDate: Date?)
 
                 static let exposedStates: [Self] = [.exposed1, .exposed5, .exposed10, .exposed20]
 

--- a/DP3TApp/Logic/Travel/CountryHelper.swift
+++ b/DP3TApp/Logic/Travel/CountryHelper.swift
@@ -26,17 +26,15 @@ final class CountryHelper {
             label.backgroundColor = .white
             label.frame = CGRect(x: 0, y: 0, width: 26, height: 20)
             label.clipsToBounds = true
-            
+
             let renderer = UIGraphicsImageRenderer(size: label.bounds.size)
-            let image = renderer.image { ctx in
+            let image = renderer.image { _ in
                 label.drawHierarchy(in: label.bounds, afterScreenUpdates: true)
             }
 
             image.accessibilityLabel = Self.localizedNameForCountryCode(code)
             return image
-
         }
-
     }
 
     static func localizedNameForCountryCode(_ code: String) -> String {

--- a/DP3TApp/Screens/Debugscreen/NSDebugScreenMockView.swift
+++ b/DP3TApp/Screens/Debugscreen/NSDebugScreenMockView.swift
@@ -97,7 +97,7 @@
                     case 5:
                         stateManager.overwrittenInfectionState = .exposed20
                     case 6:
-                        stateManager.overwrittenInfectionState = .infected(onsetDate: Date())
+                        stateManager.overwrittenInfectionState = .infected(oldestSharedKeyDate: Date())
                     default:
                         stateManager.overwrittenInfectionState = nil
                     }

--- a/DP3TApp/Screens/Homescreen/InformBroadcast/CodeInput/NSCodeInputViewController.swift
+++ b/DP3TApp/Screens/Homescreen/InformBroadcast/CodeInput/NSCodeInputViewController.swift
@@ -171,7 +171,7 @@ class NSCodeInputViewController: NSInformStepViewController, NSCodeControlProtoc
                 // success
                 // reschedule next fake request
                 FakePublishManager.shared.rescheduleFakeRequest(force: true)
-                self.navigationController?.pushViewController(NSInformThankYouViewController(onsetDate: ReportingManager.shared.onsetDate), animated: true)
+                self.navigationController?.pushViewController(NSInformThankYouViewController(onsetDate: ReportingManager.shared.oldestSharedKeyDate), animated: true)
                 self.changePresentingViewController()
             }
         }


### PR DESCRIPTION
Related to https://github.com/DP-3T/dp3t-app-ios-ch/pull/416
Instead of showing just the onset date we now show the oldest key date which was submitted to the backend.
