### PR TITLE
PP-945: initialize continue button correctly

### DIFF
--- a/DP3TApp/Screens/Onboarding/NSOnboardingBaseViewController.swift
+++ b/DP3TApp/Screens/Onboarding/NSOnboardingBaseViewController.swift
@@ -217,6 +217,11 @@ class NSOnboardingBaseViewController: NSViewController {
                 self.setOnboardingStep(self.currentStep + 1, animated: true)
             }
         }
+
+        // initialize continue button to first text
+        if let cbt = stepViewControllers.first?.continueButtonText {
+            continueButton.title = cbt
+        }
     }
 
     override func viewSafeAreaInsetsDidChange() {


### PR DESCRIPTION
Different update boarding can have a different starting text for the continue button, initialize the continue button correctly. Otherwise button title is first changed in viewDidAppear which leads to a flickering of the button title.